### PR TITLE
removing social link from body

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,8 +61,6 @@
 
 <CallToAction />
 
-<SocialLink />
-
 <div class="mt-20 flex flex-col items-center gap-10">
 	<div class="content flex flex-col gap-2">
 		<h1>


### PR DESCRIPTION
- Social links look better in the footer, therefore removing from body section.
- And is repetitive.