### PR TITLE
feat: adds redirection setup for links, closes #31

### DIFF
--- a/src/lib/config/redirects.ts
+++ b/src/lib/config/redirects.ts
@@ -1,0 +1,24 @@
+/**
+ * Configuration for external redirects
+ * path: the local path that should redirect (without leading slash)
+ * url: the external URL to redirect to
+ * type: 'permanent' (301) or 'temporary' (302)
+ */
+export interface Redirect {
+	path: string;
+	url: string;
+	type?: 'permanent' | 'temporary';
+}
+
+export const redirects: Redirect[] = [
+	{
+		path: 'friends',
+		url: 'https://chat.whatsapp.com/CbIu7z6ITmGFvwfw0BjDdL',
+		type: 'permanent'
+	},
+	{
+		path: 'conference',
+		url: 'https://hasgeek.com/vizchitra/vizchitra-2025',
+		type: 'permanent'
+	}
+];

--- a/src/lib/config/redirects.ts
+++ b/src/lib/config/redirects.ts
@@ -18,7 +18,12 @@ export const redirects: Redirect[] = [
 	},
 	{
 		path: 'conference',
-		url: 'https://hasgeek.com/vizchitra/vizchitra-2025',
+		url: 'https://hasgeek.com/VizChitra/2025',
+		type: 'permanent'
+	},
+	{
+		path: 'cfp',
+		url: 'https://hasgeek.com/VizChitra/2025/sub',
 		type: 'permanent'
 	}
 ];

--- a/src/routes/[...path]/+server.ts
+++ b/src/routes/[...path]/+server.ts
@@ -1,0 +1,15 @@
+import { redirects } from '$lib/config/redirects';
+import { redirect } from '@sveltejs/kit';
+
+export async function GET({ params }) {
+	const path = params.path;
+	const redirectConfig = redirects.find((r) => r.path === path);
+
+	if (redirectConfig) {
+		// Throw a redirect with the appropriate status code
+		throw redirect(redirectConfig.type === 'permanent' ? 301 : 302, redirectConfig.url);
+	}
+
+	// If no redirect is found, let SvelteKit handle the 404
+	return new Response('Not Found', { status: 404 });
+}


### PR DESCRIPTION
Adds way to setup redirects in a scalable manner. 

Links can be setup at `lib/config/redirects.ts` like so: 
```js

export const redirects: Redirect[] = [
	{
		path: 'friends',
		url: 'https://chat.whatsapp.com/CbIu7z6ITmGFvwfw0BjDdL',
		type: 'permanent'
	},
	{
		path: 'conference',
		url: 'https://hasgeek.com/vizchitra/vizchitra-2025',
		type: 'permanent'
	}
];

```

And are handled automatically.