### PR TITLE
fix: correct typo in brand name

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -21,7 +21,7 @@
 			<SocialLink />
 
 			<p class="bg-white text-sm opacity-75">
-				Copyright © {new Date().getFullYear()} Vizchitra. All rights reserved.
+				Copyright © {new Date().getFullYear()} VizChitra. All rights reserved.
 			</p>
 		</div>
 	</footer>

--- a/src/routes/polygon-playground/+page.svelte
+++ b/src/routes/polygon-playground/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <div class="min-h-screen w-full">
-	<PageHeader title="Create your own Vizchitra selfie!" />
+	<PageHeader title="Create your own VizChitra selfie!" />
 
 	<div class="content-container mx-auto !max-w-[min(90vw,1400px)] !px-0 py-12">
 		<p class="content-text mb-10">


### PR DESCRIPTION
Page URL: https://vizchitra.com/polygon-playground
**Before:** 
<img width="1381" height="221" alt="before" src="https://github.com/user-attachments/assets/70aa41cc-62ac-4643-9e4d-566c49d55690" />

**After:**
<img width="1391" height="225" alt="image" src="https://github.com/user-attachments/assets/171fb703-085c-42aa-b7e7-c3ee7ff8541e" />

Website Footer:
**Before:** 
<img width="465" height="146" alt="test" src="https://github.com/user-attachments/assets/790d9858-aa28-4ef6-962c-0e571f4b9248" />

**After:**
<img width="477" height="150" alt="image" src="https://github.com/user-attachments/assets/ee7df0db-f938-4a48-be8e-63c90a1f088d" />
