### PR TITLE
Close submissions and update site for browsing mode

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,9 +39,9 @@
 			<Button href="/2026" color="pink">Go to our 2026 page</Button>
 		</Cluster>
 
-		<Cluster>
+		<!-- <Cluster>
 			<Text type="caption">Accepting Submissions till <strong>15 Feb 2025, 23:59 IST</strong></Text>
-		</Cluster>
+		</Cluster> -->
 
 		<DividerCurves />
 

--- a/src/routes/2026/+page.svelte
+++ b/src/routes/2026/+page.svelte
@@ -38,18 +38,18 @@
 		<DividerCurves />
 
 		<Heading tag="h2" class="font-normal">
-			<Slanted textContent="APPLICATIONS ARE OPEN" />
+			<Slanted color="blue" textContent="BROWSE SUBMISSIONS" />
 		</Heading>
 
 		<Text type="body">
-			We invite submissions across across four formats—<ColorSpan color="blue">Talks</ColorSpan>,
+			We invited submissions across across four formats—<ColorSpan color="blue">Talks</ColorSpan>,
 			<ColorSpan color="teal">Dialogues</ColorSpan>,
 			<ColorSpan color="pink">Workshops</ColorSpan>, and
-			<ColorSpan color="orange">Exhibition</ColorSpan>. Select the one that best suits your
-			contribution.
+			<ColorSpan color="orange">Exhibition</ColorSpan>. Last day for submissions was on 15 Feb,
+			2026. You can explore all the submitted proposals below.
 		</Text>
 
-		<Cluster justify="start">
+		<!-- <Cluster justify="start">
 			<Button href="/2026/proposals" color="pink">Submit your Proposal</Button>
 			<Button href="/2026/exhibition" color="orange">Submit for Exhibition</Button>
 		</Cluster>
@@ -64,10 +64,10 @@
 			<Slanted color="blue" textContent="BROWSE SUBMISSIONS" />
 		</Heading>
 
-		<Text type="lead">
+		<Text type="body">
 			Explore all submitted proposals for VizChitra 2026. Browse talks, dialogues, workshops, and
 			exhibitions from our community.
-		</Text>
+		</Text> -->
 
 		<Cluster justify="start">
 			<Button href="/2026/submissions" color="blue">View all Submissions</Button>

--- a/src/routes/2026/exhibition/+page.svelte
+++ b/src/routes/2026/exhibition/+page.svelte
@@ -34,11 +34,11 @@
 			</p>
 		</Prose>
 
-		<Text type="caption">Exhibition Deadline: <strong>15 Feb 2025, 23:59 IST</strong></Text>
+		<Text type="caption">Exhibition Submission closed on <strong>15 Feb 2025</strong></Text>
 		<Cluster justify="start">
-			<Button href="https://forms.vizchitra.com/exhibition" color="orange" external={true}
+			<!-- <Button href="https://forms.vizchitra.com/exhibition" color="orange" external={true}
 				>Submit for Exhibition</Button
-			>
+			> -->
 			<Button href="/2026/submissions" color="blue">View all Submissions</Button>
 		</Cluster>
 

--- a/src/routes/2026/proposals/+page.svelte
+++ b/src/routes/2026/proposals/+page.svelte
@@ -40,11 +40,11 @@
 			</p>
 		</Prose>
 
-		<Text type="caption">Proposal Deadline: <strong>15 Feb 2025, 23:59 IST</strong></Text>
+		<Text type="caption">Proposal Submissions closed on <strong>15 Feb 2025</strong></Text>
 		<Cluster justify="start">
-			<Button href="https://forms.vizchitra.com/proposals" color="pink" external={true}
+			<!-- <Button href="https://forms.vizchitra.com/proposals" color="pink" external={true}
 				>Submit your Proposal</Button
-			>
+			> -->
 
 			<Button href="/2026/submissions" color="blue">View all Submissions</Button>
 		</Cluster>


### PR DESCRIPTION
## Summary
- Closes submission period for VizChitra 2026 (deadline was Feb 15, 2026)
- Updates all pages to reflect closed submissions and focus on browsing
- Removes submission call-to-action buttons

## Changes
- **Home page**: Comment out submission deadline notice
- **2026 page**: Change heading from "APPLICATIONS ARE OPEN" to "BROWSE SUBMISSIONS"
- **2026 page**: Update text from present to past tense
- **2026 page**: Comment out submission buttons
- **2026 page**: Remove duplicate browse section
- **Exhibition page**: Update deadline text to past tense
- **Exhibition page**: Comment out submission button
- **Proposals page**: Update deadline text to past tense
- **Proposals page**: Comment out submission button

All pages now prominently feature "View all Submissions" button for browsing.

## Test plan
- [x] Build succeeds with `pnpm build`
- [x] Verify home page no longer shows submission deadline
- [x] Verify 2026 page shows "BROWSE SUBMISSIONS" heading
- [x] Verify submission buttons are hidden on all pages
- [x] Verify "View all Submissions" button works on all pages
- [x] Check that deadline text shows past tense on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)