### PR TITLE
fix: restore default routes exclude to fix /friends and /map redirects

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,8 +13,7 @@ const config = {
 	kit: {
 		adapter: adapter({
 			routes: {
-				include: ['/api/*'],
-				exclude: []
+				include: ['/api/*']
 			}
 		}),
 		alias: {


### PR DESCRIPTION
## Problem

`/friends` and `/map` were 404ing on the deployed site while other redirects worked.

## Root Cause

`svelte.config.js` had `exclude: []` in the adapter-cloudflare routes config. This overrode the adapter's default, preventing it from adding redirect source paths to `_routes.json`'s exclude list. Cloudflare Pages then sent `/friends` and `/map` to the SvelteKit Worker, which returned 404.

## Fix

Removed `exclude: []` — one line deleted in `svelte.config.js`. The adapter now generates a correct `_routes.json` that bypasses the Worker for redirect paths, letting Cloudflare Pages process `_redirects` natively.

## Tested

- `pnpm build` passes
- `.svelte-kit/cloudflare/_redirects` contains all rules including `/friends` and `/map`
- `.svelte-kit/cloudflare/_routes.json` correctly includes only `/api/*` in the Worker