### PR TITLE
fix: use rel=external on /friends links to prevent SvelteKit interception

### DIFF
--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -12,6 +12,6 @@ At VizChitra, we’re not just creating data stories; we’re building a culture
 
 ## :slanted[FRIENDS of VIZCHITRA]
 
-We have more than 1,800 people in the community, which we refer to as **Friends of VizChitra**. The primary mode of conversation is through _The VizChitra Community Group_ on WhatsApp. You can join them on WhatsApp at [vizchitra.com/friends](https://vizchitra.com/friends)
+We have more than 1,800 people in the community, which we refer to as **Friends of VizChitra**. The primary mode of conversation is through _The VizChitra Community Group_ on WhatsApp. You can join them on WhatsApp at <a href="https://vizchitra.com/friends" rel="external">vizchitra.com/friends</a>
 
-[Join the Friends of VizChitra Group](https://vizchitra.com/friends)
+<a href="https://vizchitra.com/friends" rel="external">Join the Friends of VizChitra Group</a>


### PR DESCRIPTION
## Problem

`https://vizchitra.com/friends` works when typed directly in the browser (Cloudflare's `_redirects` applies), but **not when clicked from the `/community` page**.

SvelteKit intercepts same-origin clicks and fetches `__data.json` for client-side navigation instead of doing a full browser request. Since `/friends` is not a prerendered page (it's only in `_redirects`), the `__data.json` fetch returns 404 and the redirect never fires.

## Fix

Added `rel="external"` to the two `/friends` links in `community.md`. This tells SvelteKit's router to skip interception and let the browser do a full navigation — so the CDN `_redirects` rule kicks in and redirects to WhatsApp.

## Test plan

- [ ] Click "Join the Friends of VizChitra Group" from `/community` — should redirect to WhatsApp
- [ ] Visit `https://vizchitra.com/friends` directly — should still redirect to WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)