### PR TITLE
fix: CallCard mobile overflow, PatternCircle offset, layout polish

### DIFF
--- a/src/lib/components/interface/CallCard.svelte
+++ b/src/lib/components/interface/CallCard.svelte
@@ -111,14 +111,17 @@
 		<div class="pointer-events-none relative z-10 h-full p-8">
 			<!-- Title + Subtitle block -->
 			{#if title}
-				<div class={titlePositionClass} style={titleWidth ? `width: ${titleWidth}` : undefined}>
+				<div
+					class={titlePositionClass}
+					style={titleWidth ? `width: min(${titleWidth}, calc(100% - 2rem))` : undefined}
+				>
 					<h3
-						class="font-display text-viz-black text-2xl leading-tight font-bold uppercase drop-shadow-lg md:text-3xl"
+						class="font-display text-viz-black mx-1 mt-0 text-2xl leading-tight font-bold uppercase drop-shadow-lg md:text-3xl"
 					>
 						{title}
 					</h3>
 					{#if subtitle}
-						<p class="text-viz-black m-0 text-base leading-tight drop-shadow-md">
+						<p class="text-viz-black mx-1 mt-0 text-lg leading-tight drop-shadow-md md:text-xl">
 							{subtitle}
 						</p>
 					{/if}
@@ -129,10 +132,12 @@
 			{#if description}
 				<div
 					class={descriptionPositionClass}
-					style={descriptionWidth ? `width: ${descriptionWidth}` : undefined}
+					style={descriptionWidth
+						? `width: min(${descriptionWidth}, calc(100% - 2rem))`
+						: undefined}
 				>
 					<p
-						class="font-body text-viz-sm text-base leading-[1.1] italic drop-shadow-md {textColors[
+						class="font-body text-md mx-1 mt-0 leading-[1.1] italic drop-shadow-md {textColors[
 							tone
 						]}"
 					>

--- a/src/routes/2026/+page.svelte
+++ b/src/routes/2026/+page.svelte
@@ -50,15 +50,16 @@
 		</Heading>
 
 		<Text type="body">
-			<ColorSpan color="blue">Conference Day on July 4<sup>th</sup>, 2026</ColorSpan>: Features
+			<ColorSpan color="black">Conference Day on July 4<sup>th</sup>, 2026</ColorSpan>: Full day of
+			sessions including
 			<ColorSpan color="blue">Talks</ColorSpan>,
 			<ColorSpan color="teal">Dialogues</ColorSpan>, and the
 			<ColorSpan color="orange">Exhibition</ColorSpan> at Bangalore International Center (BIC), Bengaluru.
 		</Text>
 		<Text>
-			<ColorSpan color="pink">Workshop Day on July 3<sup>rd</sup>, 2026</ColorSpan>: Dedicated to
-			hands-on
-			<ColorSpan color="pink">Workshops</ColorSpan> in central Bangalor near BIC, with details coming
+			<ColorSpan color="black">Workshop Day on July 3<sup>rd</sup>, 2026</ColorSpan>: Multiple
+			half-day hands-on
+			<ColorSpan color="pink">Workshops</ColorSpan> in central Bengaluru near BIC, with details coming
 			soon.
 		</Text>
 
@@ -71,9 +72,9 @@
 						description="Deep dives into projects & lived experiences. Stories that reshape how we see our viz work."
 						pattern="waves"
 						tone="blue"
-						titlePosition="top-6 left-4 text-left"
+						titlePosition="top-5 left-3 text-left"
 						titleWidth="15ch"
-						descriptionPosition="bottom-3 left-4 text-left"
+						descriptionPosition="bottom-2 left-3 text-left"
 						descriptionWidth="30ch"
 						href="/2026"
 					/>
@@ -82,12 +83,12 @@
 					<CallCard
 						title="Dialogues"
 						subtitle="The Shared Journey"
-						description="Participant-driven, unconference-style sessions. Meaning emerges through conversation."
+						description="Participant-driven, unconference-style sessions. Meaning that emerges through conversation."
 						pattern="river"
 						tone="teal"
-						titlePosition="top-20 left-5 text-left"
-						descriptionPosition="top-40 left-5 text-left"
-						descriptionWidth="20ch"
+						titlePosition="top-18 left-3 text-left"
+						descriptionPosition="top-37 left-3 text-left"
+						descriptionWidth="16ch"
 						href="/2026"
 					/>
 				</Stack>
@@ -95,12 +96,12 @@
 					<CallCard
 						title="Exhibition"
 						subtitle="The Immersive Journey"
-						description="Data, Otherwise: a curated gallery on climate & ecology. Viz that makes you slow down & converse."
+						description="Data, Otherwise: a curated gallery on climate & ecology viz. Works that slow you down & feel."
 						pattern="stream"
 						tone="orange"
 						titlePosition="top-5 left-1/2 -translate-x-1/2 text-center"
 						titleWidth="30ch"
-						descriptionPosition="bottom-3 left-1/2 -translate-x-1/2 text-center"
+						descriptionPosition="bottom-2 left-1/2 -translate-x-1/2 text-center"
 						descriptionWidth="30ch"
 						href="/2026"
 					/>
@@ -112,8 +113,8 @@
 						description="Half-day, hands-on sessions with expert facilitators. Skill-building & learning through doing."
 						pattern="circle"
 						tone="pink"
-						titlePosition="top-35 left-1/2 -translate-x-1/2 text-center"
-						descriptionPosition="bottom-3 left-1/2 -translate-x-1/2 text-center"
+						titlePosition="top-32 left-1/2 -translate-x-1/2 text-center"
+						descriptionPosition="bottom-2 left-1/2 -translate-x-1/2 text-center"
 						descriptionWidth="30ch"
 						href="/2026"
 						variation={0.5}


### PR DESCRIPTION
## Summary

Follow-up fixes after merging the PatternArc / What's On PR.

### CallCard mobile fix
- Use `min(Nch, calc(100% - 3rem))` for `titleWidth`/`descriptionWidth` so fixed `ch` values never overflow card bounds on narrow viewports

### PatternCircle
- Add `CENTER_OFFSET_Y` constant with intuitive `-1` (top) → `0` (centre) → `+1` (bottom) scale

### 2026 page layout polish
- Refined card positions and copy for all four CallCards