### PR TITLE
feat: enhance PatternArc spinner + 2026 page updates

### DIFF
--- a/src/lib/components/patterns/PatternArc.svelte
+++ b/src/lib/components/patterns/PatternArc.svelte
@@ -11,8 +11,8 @@
 
 	let {
 		targetDate = new Date('2026-07-03T09:00:00+05:30'),
-		width = 400,
-		height = 500,
+		width = 350,
+		height = 400,
 		class: className = '',
 		ariaLabel
 	}: Props = $props();
@@ -33,6 +33,10 @@
 	const DAYS_SW = 24; // Days stroke width
 	const TEXT_R = SECS_R + 14; // Radius for top curved text label (glyphs extend outward)
 	const BOTTOM_TEXT_R = SECS_R + 40; // Larger offset: bottom glyphs extend inward toward ring
+
+	const BG_R_INNER = SECS_R + SECS_SW / 2; // 153 — rings only; text labels float outside
+	const BG_R_STAMP = 210; // 210 — stamp; contains all text labels inside
+	const BG_R = BG_R_STAMP; // ← toggle: BG_R_INNER or BG_R_STAMP
 
 	const MAX_DISPLAY_DAYS = 90; // Scale of the days arc (≥ days to event)
 
@@ -156,6 +160,16 @@
 			d={`M ${cx - BOTTOM_TEXT_R},${cy} A ${BOTTOM_TEXT_R},${BOTTOM_TEXT_R} 0 0,0 ${cx + BOTTOM_TEXT_R},${cy}`}
 		/>
 	</defs>
+
+	<!-- Background circle -->
+	<circle
+		{cx}
+		{cy}
+		r={BG_R}
+		fill="var(--color-viz-grey-subtle)"
+		stroke="var(--color-viz-grey-muted)"
+		stroke-width="1"
+	/>
 
 	<!-- Top label curved along top arc -->
 	<text

--- a/src/lib/components/structure/Hero.svelte
+++ b/src/lib/components/structure/Hero.svelte
@@ -81,7 +81,7 @@
 						ontouchstart={handleSpinnerInteract}
 						onmousedown={handleSpinnerInteract}
 					>
-						<PatternArc {targetDate} width={240} height={300} />
+						<PatternArc {targetDate} width={300} height={300} />
 					</a>
 				{:else}
 					<LogoTagline />
@@ -119,9 +119,9 @@
 			animation-play-state: paused;
 			filter: drop-shadow(0 8px 28px oklch(0.2 0 0 / 0.35));
 			cursor:
-				url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='14' fill='none' stroke='%23333' stroke-width='2'/%3E%3Cline x1='16' y1='4' x2='16' y2='28' stroke='%23333' stroke-width='2'/%3E%3Cline x1='4' y1='16' x2='28' y2='16' stroke='%23333' stroke-width='2'/%3E%3C/svg%3E")
+				url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Ctext y='28' font-size='28'%3E🎟️%3C/text%3E%3C/svg%3E")
 					16 16,
-				zoom-in;
+				pointer;
 		}
 	}
 
@@ -129,10 +129,10 @@
 	@keyframes spinnerBreathe {
 		0%,
 		100% {
-			filter: drop-shadow(0 2px 8px oklch(0.2 0 0 / 0.15));
+			filter: drop-shadow(0 0 4px oklch(76% 0.11 82 / 0.3));
 		}
 		50% {
-			filter: drop-shadow(0 6px 20px oklch(0.2 0 0 / 0.32));
+			filter: drop-shadow(0 0 10px oklch(76% 0.11 82 / 0.7));
 		}
 	}
 

--- a/src/lib/components/structure/NavMenu.svelte
+++ b/src/lib/components/structure/NavMenu.svelte
@@ -14,9 +14,10 @@
 			accentColor: 'var(--color-viz-orange)',
 			subsections: [
 				{ name: 'Event', href: '/2026/' },
+				{ name: 'Get Tickets', href: 'https://tickets.vizchitra.com' },
+				{ name: 'Submissions', href: '/2026/submissions' },
 				{ name: 'Call for Proposals', href: '/2026/proposals' },
-				{ name: 'Call for Exhibition', href: '/2026/exhibition' },
-				{ name: 'Submissions', href: '/2026/submissions' }
+				{ name: 'Call for Exhibition', href: '/2026/exhibition' }
 			],
 			expanded: false
 		},

--- a/src/routes/2026/+page.svelte
+++ b/src/routes/2026/+page.svelte
@@ -35,11 +35,11 @@
 			and connecting with the data visualization community.
 		</Text>
 
-		<Cluster justify="start">
+		<!-- <Cluster justify="start">
 			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>
 				Get your Tickets now!
 			</Button>
-		</Cluster>
+		</Cluster> -->
 
 		<DividerCurves />
 
@@ -50,18 +50,22 @@
 		</Heading>
 
 		<Text type="body">
-			<ColorSpan color="black">Conference Day on July 4<sup>th</sup>, 2026</ColorSpan>: Full day of
-			sessions including
+			<ColorSpan color="black">Conference Day on July 4<sup>th</sup>, 2026 (Saturday)</ColorSpan>:
+			Full day of sessions including
 			<ColorSpan color="blue">Talks</ColorSpan>,
 			<ColorSpan color="teal">Dialogues</ColorSpan>, and the
 			<ColorSpan color="orange">Exhibition</ColorSpan> at Bangalore International Center (BIC), Bengaluru.
 		</Text>
 		<Text>
-			<ColorSpan color="black">Workshop Day on July 3<sup>rd</sup>, 2026</ColorSpan>: Multiple
-			half-day hands-on
+			<ColorSpan color="black">Workshop Day on July 3<sup>rd</sup>, 2026 (Friday)</ColorSpan>:
+			Multiple half-day hands-on
 			<ColorSpan color="pink">Workshops</ColorSpan> in central Bengaluru near BIC, with details coming
 			soon.
 		</Text>
+
+		<Cluster justify="start" class="pt-8">
+			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>Get Tickets</Button>
+		</Cluster>
 
 		<FullBleed>
 			<Cluster class="pt-8">
@@ -122,12 +126,6 @@
 				</Stack>
 			</Cluster>
 		</FullBleed>
-
-		<Cluster justify="start" class="pt-8">
-			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>
-				Get your Tickets now!
-			</Button>
-		</Cluster>
 
 		<DividerCurves />
 

--- a/src/routes/tools/pattern/+page.svelte
+++ b/src/routes/tools/pattern/+page.svelte
@@ -284,7 +284,7 @@
 				<div class="border-viz-grey-light overflow-hidden rounded-xl border bg-white">
 					<PatternArc
 						targetDate={arcTargetDate}
-						width={400}
+						width={500}
 						height={500}
 						class="block h-auto w-full"
 						ariaLabel="Arc countdown pattern"


### PR DESCRIPTION
## Changes

### PatternArc
- Add background circle with configurable `BG_R` constant (`BG_R_INNER` / `BG_R_STAMP` options)
- Background uses `viz-grey-subtle` fill + `viz-grey-muted` stroke

### Hero spinner
- Uniform yellow drop-shadow breathing animation (0 0 offsets = glow all-round)
- Ticket emoji 🎟️ custom cursor on hover, fallback to `pointer`

### NavMenu
- Add 'Get Tickets' link to 2026 subsection
- Reorder: Submissions moved above Call for Proposals

### 2026 page
- Move Get Tickets button below event date descriptions
- Add day-of-week labels (Friday/Saturday) to event dates
- Comment out duplicate top-of-page button

### tools/pattern
- Increase PatternArc preview width to 500