### PR TITLE
fix: SessionCardExpanded layout broken in Safari desktop

### DIFF
--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -91,7 +91,9 @@
 	const overlayStrokeWidth = 12;
 
 	let screenWidth = $state(0);
-	let patternHeight = $state(0);
+	const waveHeight = $derived(
+		Math.round((backgroundWidth * (364 - overlayStrokeWidth)) / (1080 - 2 * overlayStrokeWidth))
+	);
 </script>
 
 <svelte:window bind:innerWidth={screenWidth} />
@@ -227,8 +229,7 @@
 				{/if}
 			</div>
 			<div
-				class="background-container-expanded relative z-0 flex w-full flex-row items-center justify-end"
-				style:height="100%"
+				class="background-container-expanded relative z-0 flex w-full flex-1 flex-row items-center justify-end"
 			>
 				<SessionCardBackground
 					{sessionType}
@@ -252,11 +253,8 @@
 				</div>
 			</div>
 
-			<div
-				class="speaker-details-overlay pointer-events-auto relative mt-auto flex flex-col"
-				style:height="{patternHeight}px"
-			>
-				<div class="absolute inset-x-0 bottom-0">
+			<div class="speaker-details-overlay pointer-events-auto relative flex flex-col">
+				<div class="absolute inset-x-0 bottom-0" style:height="{waveHeight}px">
 					<svg
 						class="relative z-0 block h-full w-full"
 						viewBox="{overlayStrokeWidth} 0 {1080 - 2 * overlayStrokeWidth} {364 -
@@ -264,7 +262,6 @@
 						preserveAspectRatio="none"
 						fill="none"
 						aria-hidden="true"
-						bind:clientHeight={patternHeight}
 					>
 						<path
 							class="fill {color}"
@@ -357,8 +354,9 @@
 							{#each speakerName.split('/').map((s) => s.trim()) as person, i}
 								{#if i > 0}<span
 										class="text-xl leading-none font-medium md:text-[28px] 2xl:text-3xl"
-										> / </span
-									>{/if}
+									>
+										/
+									</span>{/if}
 								<span
 									class="first-name text-xl leading-none font-extrabold md:text-[28px] 2xl:text-3xl"
 									>{person.split(' ')[0]}</span


### PR DESCRIPTION
## Problem
The workshop/session cards rendered correctly in Chrome and mobile Safari but collapsed in Safari desktop (including Safari 26.4). Two Safari-specific bugs were responsible:

1. **`height: 100%` on flex child** — Safari does not treat `aspect-ratio` as a "definite" height for percentage resolution on flex children. `.background-container-expanded` was set to `height: 100%`, which Safari resolved to `0`, collapsing the speaker image area.

2. **`bind:clientHeight` on `<svg>`** — Safari returns `0` for `clientHeight` on inline SVG elements. `patternHeight` was bound to the wave SVG's height, then used to explicitly size the speaker overlay container — so it too collapsed to `0px`.

## Fix
- Replace `style:height="100%"` with `flex-1` on `.background-container-expanded` so it fills remaining space via flexbox rather than percentage resolution.
- Remove `bind:clientHeight` from the SVG. Instead, derive `waveHeight` from the already-reliable `bind:clientWidth` on a plain `<div>` using the SVG viewBox aspect ratio (`(364 − strokeWidth) / (1080 − 2 × strokeWidth)`).

## Testing
- [x] Chrome desktop — no regression
- [x] Mobile Safari — no regression
- [ ] Safari desktop 26.4 — please verify