### PR TITLE
fix: session card wave flash, edge clipping and white line

### DIFF
--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -161,10 +161,10 @@
 	{@const currentColor = colorClasses[color] ?? colorClasses.blue}
 	<a
 		href={detailHref}
-		class="sessions-card group white border-viz-grey/40 mx-auto block w-full overflow-hidden rounded border isolate transform-gpu transition-[transform,box-shadow] hover:scale-102"
+		class="sessions-card group white border-viz-grey/40 isolate mx-auto block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] hover:scale-102"
 	>
 		<div
-			class="session-card-body relative flex aspect-4/7 max-h-[85svh] flex-col overflow-visible md:aspect-4/5.75 md:max-h-none"
+			class="session-card-body relative flex aspect-4/5.75 max-h-[85svh] flex-col overflow-visible md:max-h-none"
 			bind:clientWidth={backgroundWidth}
 			bind:clientHeight={backgroundHeight}
 		>

--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -161,7 +161,7 @@
 	{@const currentColor = colorClasses[color] ?? colorClasses.blue}
 	<a
 		href={detailHref}
-		class="sessions-card group white border-viz-grey/40 mx-auto block w-full overflow-hidden rounded border transition-[transform,box-shadow] hover:scale-102"
+		class="sessions-card group white border-viz-grey/40 mx-auto block w-full overflow-hidden rounded border isolate transform-gpu transition-[transform,box-shadow] hover:scale-102"
 	>
 		<div
 			class="session-card-body relative flex aspect-4/7 max-h-[85svh] flex-col overflow-visible md:aspect-4/5.75 md:max-h-none"

--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -83,7 +83,7 @@
 
 	const formattedDate = $derived(date ? formatDate(date) : '');
 
-	let backgroundWidth = $state(600);
+	let backgroundWidth = $state(0);
 	let backgroundHeight = $derived.by(() => backgroundWidth * 1.25);
 	let expandedBgWidth = $derived(backgroundWidth * 0.55);
 
@@ -91,9 +91,6 @@
 	const overlayStrokeWidth = 12;
 
 	let screenWidth = $state(0);
-	const waveHeight = $derived(
-		Math.round((backgroundWidth * (364 - overlayStrokeWidth)) / (1080 - 2 * overlayStrokeWidth))
-	);
 </script>
 
 <svelte:window bind:innerWidth={screenWidth} />
@@ -253,97 +250,114 @@
 				</div>
 			</div>
 
-			<div class="speaker-details-overlay pointer-events-auto relative flex flex-col">
-				<div class="absolute inset-x-0 bottom-0" style:height="{waveHeight}px">
-					<svg
-						class="relative z-0 block h-full w-full"
-						viewBox="{overlayStrokeWidth} 0 {1080 - 2 * overlayStrokeWidth} {364 -
-							overlayStrokeWidth}"
-						preserveAspectRatio="none"
-						fill="none"
-						aria-hidden="true"
-					>
-						<path
-							class="fill {color}"
-							d="M0.5 364.516V0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1080 2.01636V364.516H0.5Z"
-							fill={overlayColors[color] ?? overlayColors.blue}
-							stroke="#fff"
-							stroke-width={overlayStrokeWidth}
-						/>
-					</svg>
-
-					{#if showViewDetailsButton}
+			<div
+				class="speaker-details-overlay pointer-events-auto relative flex flex-col"
+				style:background-color={overlayColors[color] ?? overlayColors.blue}
+			>
+				<!-- wave height = card-width/3; padding-bottom% is relative to own width (inset-x-0) -->
+				<div
+					class="absolute inset-x-0 -bottom-px"
+					style="height: 0; padding-bottom: calc(33.34% + 2px);"
+				>
+					<div class="absolute inset-0">
 						<svg
-							class="view-details-button absolute -right-10 -bottom-8 z-40 block h-40 w-40 origin-center scale-0 transition-transform duration-400 ease-out group-hover:scale-100 md:h-50 md:w-50 lg:-right-16 lg:-bottom-16 lg:h-60 lg:w-60"
+							class="relative z-0 block h-full w-full"
+							viewBox="0 0 1080 364"
 							preserveAspectRatio="none"
-							viewBox="0 0 200 200"
 							fill="none"
 							aria-hidden="true"
 						>
-							<defs>
-								<path
-									id="view-details-path-{slug}"
-									d="M 100,100 m -{textPathRadius},0 a {textPathRadius},{textPathRadius} 0 1,1 {textPathRadius *
-										2},0 a {textPathRadius},{textPathRadius} 0 1,1 -{textPathRadius * 2},0"
-									fill="none"
-								/>
-							</defs>
-
-							<circle
-								cx="100"
-								cy="100"
-								r="80"
-								fill="#fff"
-								stroke="var(--color-{colorClasses[color]})"
-								stroke-width="7"
-								fill-opacity="1"
+							<!-- filled wave shape, no stroke -->
+							<path
+								d="M-12 364.516V0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636V364.516H-12Z"
+								fill={overlayColors[color] ?? overlayColors.blue}
 							/>
-
-							<circle
-								cx="100"
-								cy="100"
-								r="52"
-								fill="var(--color-{colorClasses[color]}-dark)"
-								stroke-width="10"
-								fill-opacity="0.75"
-							/>
-
-							<circle
-								cx="100"
-								cy="100"
-								r="45"
-								fill="var(--color-{colorClasses[color]})"
-								fill-opacity="1"
-							/>
-							<circle cx="100" cy="100" r="35" fill="#fff" fill-opacity="1" />
-
-							<g
-								transform="translate(100 100) scale(0.325) translate(-63 -63)"
-								stroke="#4c4c4c"
-								stroke-width="13"
-								stroke-linecap="round"
-								stroke-linejoin="round"
+							<!-- white stroke only on the top curve, not on bottom/sides -->
+							<path
+								d="M-12 0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636"
 								fill="none"
-							>
-								<path d="M26.25 63L99.75 63" />
-								<path d="M63 26.25L99.75 63L63 99.75" />
-							</g>
-
-							<text
-								class="view-details-text font-display"
-								fill="#4c4c4c"
-								font-size="16"
-								font-weight="800"
-								letter-spacing="2"
-								text-anchor="middle"
-							>
-								<!-- <textPath href="#view-details-path-{slug}" startOffset="0%">•</textPath> -->
-								<textPath href="#view-details-path-{slug}" startOffset="18%">VIEW DETAILS</textPath>
-								<!-- <textPath href="#view-details-path-{slug}" startOffset="50%">•</textPath> -->
-								<textPath href="#view-details-path-{slug}" startOffset="65%">VIEW DETAILS</textPath>
-							</text>
+								stroke="#fff"
+								stroke-width={overlayStrokeWidth}
+							/>
 						</svg>
-					{/if}
+
+						{#if showViewDetailsButton}
+							<svg
+								class="view-details-button absolute -right-10 -bottom-8 z-40 block h-40 w-40 origin-center scale-0 transition-transform duration-400 ease-out group-hover:scale-100 md:h-50 md:w-50 lg:-right-16 lg:-bottom-16 lg:h-60 lg:w-60"
+								preserveAspectRatio="none"
+								viewBox="0 0 200 200"
+								fill="none"
+								aria-hidden="true"
+							>
+								<defs>
+									<path
+										id="view-details-path-{slug}"
+										d="M 100,100 m -{textPathRadius},0 a {textPathRadius},{textPathRadius} 0 1,1 {textPathRadius *
+											2},0 a {textPathRadius},{textPathRadius} 0 1,1 -{textPathRadius * 2},0"
+										fill="none"
+									/>
+								</defs>
+
+								<circle
+									cx="100"
+									cy="100"
+									r="80"
+									fill="#fff"
+									stroke="var(--color-{colorClasses[color]})"
+									stroke-width="7"
+									fill-opacity="1"
+								/>
+
+								<circle
+									cx="100"
+									cy="100"
+									r="52"
+									fill="var(--color-{colorClasses[color]}-dark)"
+									stroke-width="10"
+									fill-opacity="0.75"
+								/>
+
+								<circle
+									cx="100"
+									cy="100"
+									r="45"
+									fill="var(--color-{colorClasses[color]})"
+									fill-opacity="1"
+								/>
+								<circle cx="100" cy="100" r="35" fill="#fff" fill-opacity="1" />
+
+								<g
+									transform="translate(100 100) scale(0.325) translate(-63 -63)"
+									stroke="#4c4c4c"
+									stroke-width="13"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									fill="none"
+								>
+									<path d="M26.25 63L99.75 63" />
+									<path d="M63 26.25L99.75 63L63 99.75" />
+								</g>
+
+								<text
+									class="view-details-text font-display"
+									fill="#4c4c4c"
+									font-size="16"
+									font-weight="800"
+									letter-spacing="2"
+									text-anchor="middle"
+								>
+									<!-- <textPath href="#view-details-path-{slug}" startOffset="0%">•</textPath> -->
+									<textPath href="#view-details-path-{slug}" startOffset="18%"
+										>VIEW DETAILS</textPath
+									>
+									<!-- <textPath href="#view-details-path-{slug}" startOffset="50%">•</textPath> -->
+									<textPath href="#view-details-path-{slug}" startOffset="65%"
+										>VIEW DETAILS</textPath
+									>
+								</text>
+							</svg>
+						{/if}
+					</div>
 				</div>
 
 				<div class="speaker-details-content relative z-30 mt-auto w-full p-2.5 md:p-4">

--- a/src/lib/components/sessions/speakerConfig.js
+++ b/src/lib/components/sessions/speakerConfig.js
@@ -26,7 +26,7 @@ export const speakerImageTransforms = {
 export function buildSpeakerImageTransform(name, screenWidth = 1000) {
 	const t = (name && speakerImageTransforms[name]) || {};
 	const tx = t.x ?? 0;
-	const ty = screenWidth < 768 ? t.y - 6 : t.y ?? 0;
+	const ty = screenWidth < 768 ? (t.y ?? 0) - 6 : t.y ?? 0;
 	const s = t.scale ?? 1;
 
 	return `translate(${tx}%, ${ty}%) scale(${s})`;


### PR DESCRIPTION
## Problem

Multiple visual issues with the session card wave overlay, most visible on mobile Safari:

1. **Load flash** — wave rendered large then snapped to correct size (initial `backgroundWidth=600` inflated `waveHeight` before `bind:clientWidth` fired)
2. **Wave clipped on right** — viewBox excluded the stroke area, path ended exactly at edge leaving a sliver uncoloured  
3. **White line at card bottom** — `stroke` applied to the entire closed path perimeter, so the bottom/side edges got a white stroke that showed through the card's `overflow-hidden rounded` corners
4. **NaN image transform** — `t.y - 6` for speakers not in the config map produced `NaN`, breaking the CSS transform

## Fix

- `backgroundWidth` initialised to `0` (not `600`) to avoid inflated initial wave height
- Removed JS-measured `waveHeight`; replaced with pure CSS `padding-bottom: 33.34%` on the wave container — `padding-bottom` is relative to element width, and the container is `inset-x-0` (= card width), so wave height = card-width/3 which matches the original formula exactly. Renders correctly from first CSS paint — no JS measurement, no flash.
- Wave path extended to `M-12…1092` and `viewBox` set to `0 0 1080 364` so fill bleeds past both edges before clipping
- Wave SVG split into two paths: filled shape (no stroke) + open top-curve only (white stroke) — white separator shows only on the curve, not on bottom/sides
- `speaker-details-overlay` gets matching `background-color` so rounded corner clips show the wave colour, not white
- `speakerConfig.js`: `(t.y ?? 0) - 6` fixes NaN for speakers without a config entry