### PR TITLE
feat: scholarship page and ::button markdown directive

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -24,6 +24,7 @@ const pages = defineCollection({
 		slug: z.string(),
 		banner: z.enum(['polygon', 'curve', 'square', 'blob']).optional(),
 		color: z.enum(['grey', 'pink', 'blue', 'teal', 'yellow', 'orange']).optional(),
+		ogImage: z.string().optional(),
 		draft: z.boolean().optional().default(false),
 		content: z.string().optional()
 	}),

--- a/content/pages/scholarships.md
+++ b/content/pages/scholarships.md
@@ -1,0 +1,45 @@
+---
+title: Financial Aid Scholarships
+description: 10 fully funded slots for people who wouldn't be able to attend VizChitra 2026 otherwise.
+slug: 2026/scholarships
+banner: curve
+color: pink
+---
+
+# Financial Aid Scholarships
+
+Data visualization is a field that rewards access: to tools, to education, to community. We want VizChitra to reflect the full range of people working with data in India.
+
+These financial aid scholarships exist to make that possible. If cost is standing between you and being at VizChitra 2026, apply.
+
+::button[Apply for Scholarship]{href="https://forms.vizchitra.com/scholarships" color="pink"}
+
+**Applications close May 25, 2026.**
+
+## The Scholarship
+
+With the support of Friends of VizChitra and sponsors, we are offering full scholarships for **10 individuals** to attend the VizChitra 2026. The scholarship covers the ticket cost for the Conference Day on 04 July 2026. Recipients travelling from outside Bangalore can also receive up to **₹5,000 towards travel and accommodation** (reimbursed on actuals).
+
+## Who should apply
+
+You don't need to prove anything. If any of these sound like you, this is for you:
+
+- You're a student, freelancer, early-career practitioner, or career switcher for whom the ticket cost is a real barrier.
+- You're from a Tier 2/3 city, smaller town, or non-metro India.
+- You're earlier in your journey — self-taught, switching careers, still building your foundation.
+- What you learn here will go somewhere — a classroom, a newsroom, a team, a community.
+- Your background or perspective isn't often in the room at events like this.
+
+You don't need to tick every box. If you're unsure, apply.
+
+## How it works
+
+Fill out the form before **May 25, 2026**. Applications will be reviewed by a panel from the VizChitra community based on financial need, geographic access, career stage, impact outcome, and lived experience. Final decisions will be communicated by email within a week of the deadline.
+
+Already bought a ticket? If your application is selected, we'll issue a refund.
+
+::button[Apply for Scholarship]{href="https://forms.vizchitra.com/scholarships" color="pink"}
+
+_Want to attend and can afford it? [Buy a ticket](https://tickets.vizchitra.com/) instead. It helps us offer more scholarships._
+
+_Questions? Write to us at [hello@vizchitra.com](mailto:hello@vizchitra.com)_

--- a/content/pages/scholarships.md
+++ b/content/pages/scholarships.md
@@ -4,6 +4,7 @@ description: 10 fully funded slots for people who wouldn't be able to attend Viz
 slug: 2026/scholarships
 banner: curve
 color: pink
+ogImage: /images/preview/preview-scholarships.jpg
 ---
 
 # Financial Aid Scholarships

--- a/src/lib/components/typography/Prose.svelte
+++ b/src/lib/components/typography/Prose.svelte
@@ -171,7 +171,7 @@
 			color: var(--dark-color);
 		}
 
-		& a {
+		& a:not(.btn) {
 			/* color: var(--dark-color); */
 			text-decoration: underline;
 			text-decoration-color: var(--muted-color);
@@ -180,7 +180,7 @@
 			text-decoration-skip-ink: auto;
 		}
 
-		& a:hover {
+		& a:not(.btn):hover {
 			text-decoration-color: var(--dark-color);
 			padding: 0.35em 0;
 			background-color: var(--subtle-color);

--- a/src/lib/markdown/directive.js
+++ b/src/lib/markdown/directive.js
@@ -32,6 +32,20 @@ const CONTAINER_DIRECTIVES = {
 // SECTION 3: Block/Leaf Directives (::name)
 // ============================================
 
+const BUTTON_COLOR_VARS = {
+	blue: '--color-viz-blue-solid',
+	pink: '--color-viz-pink-solid',
+	teal: '--color-viz-teal-solid',
+	orange: '--color-viz-orange-solid',
+	yellow: '--color-viz-yellow-solid'
+};
+
+const BUTTON_SIZE_CLASSES = {
+	sm: 'text-sm',
+	md: 'text-base',
+	lg: 'text-lg'
+};
+
 const BLOCK_DIRECTIVES = {
 	hr: {
 		transform: () => ({
@@ -50,6 +64,52 @@ const BLOCK_DIRECTIVES = {
 				'aria-hidden': 'true'
 			}
 		})
+	},
+
+	button: {
+		transformsChildren: true,
+		transform: (node) => {
+			const attrs = node.attributes || {};
+			const href = attrs.href || '#';
+			const color = attrs.color || 'orange';
+			const size = attrs.size || 'md';
+			const external = attrs.external === 'true' || attrs.external === '';
+			const label = getTextContent(node) || attrs.label || 'Learn More';
+
+			const bgColorVar = BUTTON_COLOR_VARS[color] ?? BUTTON_COLOR_VARS.orange;
+			const sizeClass = BUTTON_SIZE_CLASSES[size] ?? BUTTON_SIZE_CLASSES.md;
+
+			const hChildren = [{ type: 'text', value: label }];
+			if (external) {
+				hChildren.push({
+					type: 'element',
+					tagName: 'span',
+					properties: { className: ['ml-1', 'text-lg'] },
+					children: [{ type: 'text', value: '↗' }]
+				});
+			}
+
+			return {
+				hName: 'a',
+				hProperties: {
+					href,
+					...(external && { target: '_blank', rel: 'noopener noreferrer' }),
+					style: `background-color: var(${bgColorVar}); color: white;`,
+					className: [
+						'btn', 'not-prose', 'inline-flex', 'transform', 'items-center',
+						'justify-center', 'rounded-sm', 'px-4', 'py-4', 'text-center',
+						'text-xl', 'font-semibold', 'text-white', 'no-underline',
+						'transition-transform', 'duration-300', 'ease-in-out',
+						'hover:-translate-y-1', 'hover:scale-102',
+						'hover:shadow-[0_12px_30px_rgba(0,0,0,0.14),0_0_22px_rgba(255,255,255,0.06)]',
+						'focus:outline-none', 'focus-visible:ring-4',
+						'focus-visible:ring-white/10', 'focus-visible:outline-none',
+						sizeClass
+					]
+				},
+				hChildren
+			};
+		}
 	}
 };
 

--- a/src/routes/[...slug]/+page.server.ts
+++ b/src/routes/[...slug]/+page.server.ts
@@ -53,7 +53,8 @@ export const load: PageServerLoad = async ({ params }) => {
 		document: page,
 		pageMeta: {
 			title: page.title,
-			description: page.description
+			description: page.description,
+			...(page.ogImage && { ogImage: `https://vizchitra.com${page.ogImage}` })
 		},
 		pageLayout: {
 			banner: page.banner,


### PR DESCRIPTION
## Changes

### New page
- `content/pages/scholarships.md` — Financial Aid Scholarships page for VizChitra 2026 (10 fully funded slots, travel reimbursement up to ₹5,000, deadline May 25)

### New feature: `::button` leaf directive
Adds a `::button` leaf directive to `remarkVizchitraDirectives` that renders an `<a>` matching the `Button.svelte` styles.

**Usage in Markdown:**
```
::button[Register Now]{href="/register"}
::button[Apply]{href="https://forms.vizchitra.com/scholarships" color="pink" size="lg"}
::button[CFP Site]{href="https://example.com" color="teal" external="true"}
```

**Supported attributes:** `href`, `color` (orange/blue/pink/teal/yellow), `size` (sm/md/lg), `external`

### Bug fix: Prose link styles no longer affect buttons
- `Prose.svelte` link styles (`text-decoration`, hover background/padding) now use `a:not(.btn)` so they don't override button styling.