### PR TITLE
fix(oauth): pin redirect_uri to vizchitra.com via STUDIO_BASE_URL

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,6 +13,7 @@ declare global {
 				STUDIO_GITHUB_CLIENT_SECRET: string;
 				STUDIO_ALLOWED_USERS: string;
 				STUDIO_GITHUB_TOKEN?: string;
+				STUDIO_BASE_URL?: string;
 			};
 			context: ExecutionContext;
 			caches: CacheStorage & { default: Cache };

--- a/src/routes/studio/auth/github/+server.ts
+++ b/src/routes/studio/auth/github/+server.ts
@@ -28,7 +28,8 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	}
 
 	const next = url.searchParams.get('next') ?? '/studio';
-	const callbackUrl = `${url.origin}/studio/auth/callback`;
+	const origin = platform?.env?.STUDIO_BASE_URL ?? url.origin;
+	const callbackUrl = `${origin}/studio/auth/callback`;
 
 	const githubUrl = new URL('https://github.com/login/oauth/authorize');
 	githubUrl.searchParams.set('client_id', clientId);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,9 @@ compatibility_date = "2024-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".svelte-kit/cloudflare"
 
+[vars]
+STUDIO_BASE_URL = "https://vizchitra.com"
+
 [[kv_namespaces]]
 binding = "PROPOSAL_VOTES"
 id = "1e942766305343679da8071bbe2198c4"


### PR DESCRIPTION
## Problem
The GitHub OAuth callback was using `url.origin` dynamically, which could be a Cloudflare preview URL or different domain — causing `redirect_uri mismatch` errors when the registered callback URL is `https://vizchitra.com/studio/auth/callback`.

## Fix
- Added `STUDIO_BASE_URL = "https://vizchitra.com"` to `wrangler.toml` `[vars]`
- Added `STUDIO_BASE_URL?` to `Platform.env` types in `app.d.ts`
- Auth handler now reads `platform?.env?.STUDIO_BASE_URL ?? url.origin` so the `redirect_uri` always matches the registered GitHub OAuth App callback URL

## Verified
GitHub OAuth App authorization callback URL confirmed as `https://vizchitra.com/studio/auth/callback`