### PR TITLE
fix(routing): nested studio routes return 404 due to Cloudflare wildcard limitation

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,8 +13,8 @@ const config = {
 	kit: {
 		adapter: adapter({
 			routes: {
-				include: ['/api/*', '/2026/submissions/*/og-image.png', '/studio', '/studio/*'],
-				exclude: []
+				include: ['/*'],
+				exclude: ['/app/*', '/fonts/*', '/images/*', '/docs/*']
 			}
 		}),
 		alias: {


### PR DESCRIPTION
## Root cause

Cloudflare Pages `_routes.json` uses `*` wildcards that **do not match forward slashes**. The previous config had:

```js
include: ['/api/*', '/studio', '/studio/*']
```

This covered:
- ✅ `/studio/login` (one level deep)
- ✅ `/studio/auth` (one level deep)  
- ❌ `/studio/auth/github` (two levels deep — `auth/github` contains `/`)
- ❌ `/studio/auth/callback` (same issue)

So clicking "Sign in with GitHub" on the login page → `/studio/auth/github` → **404**.

## Fix

Change to `include: ['/*']` (the adapter default) so all requests reach the Worker, with `exclude` for static asset directories (`/app/*`, `/fonts/*`, `/images/*`, `/docs/*`) which are large and never dynamic.