### PR TITLE
fix(routing): nested studio routes 404 — Cloudflare wildcard doesn't cross slashes

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,8 +13,8 @@ const config = {
 	kit: {
 		adapter: adapter({
 			routes: {
-				include: ['/api/*', '/2026/submissions/*/og-image.png', '/studio', '/studio/*'],
-				exclude: []
+				include: ['/*'],
+				exclude: ['/app/*', '/fonts/*', '/images/*', '/docs/*']
 			}
 		}),
 		alias: {


### PR DESCRIPTION
## Problem

`/studio/auth/github` and `/studio/auth/callback` return 404 in production.

Cloudflare Pages `_routes.json` wildcards (`*`) **do not match forward slashes**, so `/studio/*` only covers one level deep:
- ✅ `/studio/login`
- ❌ `/studio/auth/github` (two levels)
- ❌ `/studio/auth/callback` (two levels)

## Fix

```js
// Before
include: ['/api/*', '/2026/submissions/*/og-image.png', '/studio', '/studio/*']

// After
include: ['/*'],
exclude: ['/app/*', '/fonts/*', '/images/*', '/docs/*']
```

All requests now reach the Worker. Static asset directories are excluded so large files are served directly by Cloudflare's CDN.