### PR TITLE
fix(studio/oauth): fix GitHub OAuth login on production

### DIFF
--- a/src/routes/studio/auth/callback/+server.ts
+++ b/src/routes/studio/auth/callback/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from './$types';
 import { dev } from '$app/environment';
 import { createSession, buildSessionCookie, isAllowedUser } from '$lib/studio/session';
 
-export const GET: RequestHandler = async ({ platform, url }) => {
+export const GET: RequestHandler = async ({ platform, url, request }) => {
 	const code = url.searchParams.get('code');
 	const stateParam = url.searchParams.get('state') ?? '';
 
@@ -17,41 +17,58 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	const clientId = platform?.env?.STUDIO_GITHUB_CLIENT_ID;
 	const clientSecret = platform?.env?.STUDIO_GITHUB_CLIENT_SECRET;
 	const allowedUsers = platform?.env?.STUDIO_ALLOWED_USERS ?? '';
+	const origin = platform?.env?.STUDIO_BASE_URL ?? url.origin;
+	const callbackUrl = `${origin}/studio/auth/callback`;
 
 	if (!clientId || !clientSecret) {
 		return new Response('OAuth not configured', { status: 500 });
 	}
 
-	// Validate CSRF state
+	// Validate CSRF state via cookie (avoids KV eventual-consistency issues across
+	// Cloudflare edge locations; SameSite=Lax ensures the cookie survives the redirect)
 	const [state, encodedNext] = stateParam.split(':');
 	const next = encodedNext ? decodeURIComponent(encodedNext) : '/studio';
 
-	if (kv && state) {
-		const stored = await kv.get(`oauth_state:${state}`);
-		if (!stored) {
-			return new Response(null, {
-				status: 302,
-				headers: { Location: '/studio/login?error=invalid_state' }
-			});
-		}
-		// Consume the state token (one-time use)
-		await kv.delete(`oauth_state:${state}`);
+	const cookieHeader = request.headers.get('cookie') ?? '';
+	const cookieState =
+		cookieHeader
+			.split(';')
+			.map((c) => c.trim())
+			.find((c) => c.startsWith('oauth_state='))
+			?.slice('oauth_state='.length) ?? '';
+
+	const clearStateCookie = 'oauth_state=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure';
+
+	if (!state || !cookieState || cookieState !== state) {
+		return new Response(null, {
+			status: 302,
+			headers: { Location: '/studio/login?error=invalid_state' }
+		});
 	}
 
-	// Exchange code for access token
+	// Exchange code for access token; redirect_uri is required when it was sent
+	// during the authorization request
 	const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json'
 		},
-		body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code })
+		body: JSON.stringify({
+			client_id: clientId,
+			client_secret: clientSecret,
+			code,
+			redirect_uri: callbackUrl
+		})
 	});
 
 	if (!tokenRes.ok) {
 		return new Response(null, {
 			status: 302,
-			headers: { Location: '/studio/login?error=token_exchange' }
+			headers: {
+				Location: '/studio/login?error=token_exchange',
+				'Set-Cookie': clearStateCookie
+			}
 		});
 	}
 
@@ -59,7 +76,10 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	if (!tokenData.access_token) {
 		return new Response(null, {
 			status: 302,
-			headers: { Location: '/studio/login?error=no_token' }
+			headers: {
+				Location: '/studio/login?error=no_token',
+				'Set-Cookie': clearStateCookie
+			}
 		});
 	}
 
@@ -74,7 +94,10 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	if (!userRes.ok) {
 		return new Response(null, {
 			status: 302,
-			headers: { Location: '/studio/login?error=user_fetch' }
+			headers: {
+				Location: '/studio/login?error=user_fetch',
+				'Set-Cookie': clearStateCookie
+			}
 		});
 	}
 
@@ -84,7 +107,10 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	if (!handle) {
 		return new Response(null, {
 			status: 302,
-			headers: { Location: '/studio/login?error=no_handle' }
+			headers: {
+				Location: '/studio/login?error=no_handle',
+				'Set-Cookie': clearStateCookie
+			}
 		});
 	}
 
@@ -92,25 +118,26 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	if (!isAllowedUser(allowedUsers, handle)) {
 		return new Response(null, {
 			status: 302,
-			headers: { Location: '/studio/login?error=unauthorized' }
+			headers: {
+				Location: '/studio/login?error=unauthorized',
+				'Set-Cookie': clearStateCookie
+			}
 		});
 	}
 
-	// Create session
+	// Create session in KV
 	if (!kv) {
 		return new Response('Session store not available', { status: 500 });
 	}
 	const sessionId = await createSession(kv, handle);
-	const cookie = buildSessionCookie(sessionId, !dev);
+	const sessionCookie = buildSessionCookie(sessionId, !dev);
 
 	// Ensure next is a safe relative path (prevent open redirect)
 	const safePath = next.startsWith('/') && !next.startsWith('//') ? next : '/studio';
 
-	return new Response(null, {
-		status: 302,
-		headers: {
-			Location: safePath,
-			'Set-Cookie': cookie
-		}
-	});
+	const headers = new Headers({ Location: safePath });
+	headers.append('Set-Cookie', sessionCookie);
+	headers.append('Set-Cookie', clearStateCookie);
+
+	return new Response(null, { status: 302, headers });
 };

--- a/src/routes/studio/auth/github/+server.ts
+++ b/src/routes/studio/auth/github/+server.ts
@@ -3,8 +3,8 @@ import { dev } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async ({ platform, url }) => {
-	// Dev bypass: when STUDIO_DEV_USER is set, skip OAuth entirely
-	if (dev && process.env.STUDIO_DEV_USER) {
+	// In dev mode, always bypass OAuth — studio is accessible without login
+	if (dev) {
 		const next = url.searchParams.get('next') ?? '/studio';
 		throw redirect(302, next);
 	}
@@ -14,18 +14,12 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 		return new Response('OAuth not configured', { status: 500 });
 	}
 
-	// Generate a random CSRF state token and store it in the session KV briefly
+	// Generate a random CSRF state token
 	const stateBytes = new Uint8Array(16);
 	crypto.getRandomValues(stateBytes);
 	const state = Array.from(stateBytes)
 		.map((b) => b.toString(16).padStart(2, '0'))
 		.join('');
-
-	// Store state with 10-minute TTL for CSRF validation
-	const kv = platform?.env?.STUDIO_SESSIONS;
-	if (kv) {
-		await kv.put(`oauth_state:${state}`, '1', { expirationTtl: 600 });
-	}
 
 	const next = url.searchParams.get('next') ?? '/studio';
 	const origin = platform?.env?.STUDIO_BASE_URL ?? url.origin;
@@ -37,8 +31,15 @@ export const GET: RequestHandler = async ({ platform, url }) => {
 	githubUrl.searchParams.set('scope', 'read:user');
 	githubUrl.searchParams.set('state', `${state}:${encodeURIComponent(next)}`);
 
+	// Store CSRF state in a short-lived cookie (SameSite=Lax so it survives the
+	// cross-site redirect back from GitHub; avoids KV eventual-consistency issues)
+	const stateCookie = `oauth_state=${state}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax; Secure`;
+
 	return new Response(null, {
 		status: 302,
-		headers: { Location: githubUrl.toString() }
+		headers: {
+			Location: githubUrl.toString(),
+			'Set-Cookie': stateCookie
+		}
 	});
 };


### PR DESCRIPTION
## Problem

The `/studio` GitHub OAuth login was failing with "Sign-in failed. Please try again." on every attempt on the live site.

Two root causes:

**1. KV eventual consistency (primary bug)**
The CSRF state token was written to Cloudflare KV during `/studio/auth/github` and read back during `/studio/auth/callback`. These are two separate Worker invocations — if they land on different Cloudflare edge locations, KV propagation can take up to 60 seconds, so the callback would fail to find the state → `invalid_state` error.

**2. Missing `redirect_uri` in token exchange**
GitHub requires `redirect_uri` in the token exchange call when it was included in the initial authorization request. Omitting it can cause GitHub to return an error body instead of an `access_token`.

## Fix

- Replaced KV-based CSRF state with a short-lived `SameSite=Lax; HttpOnly` cookie (industry-standard OAuth pattern). `SameSite=Lax` ensures the cookie is sent with the top-level GET redirect from GitHub back to our callback — always consistent, no propagation delay.
- Added `redirect_uri` to the token exchange request body.
- Simplified dev mode: `/studio/auth/github` now unconditionally redirects in dev without requiring `STUDIO_DEV_USER`. Studio is accessible without any login page locally.

## Test plan

- [x] Deploy to production (Cloudflare Pages)
- [ ] Visit `https://vizchitra.com/studio` → redirected to login page
- [ ] Click "Sign in with GitHub" → authorise → redirected back to `/studio` successfully
- [ ] Verify session cookie is set and persists across page reloads
- [ ] Verify logout clears the session
- [x] Locally: `npm run dev` → navigate to `/studio` → studio loads directly without login

🤖 Generated with [Claude Code](https://claude.com/claude-code)