### PR TITLE
fix(studio): content tree via import.meta.glob + force full nav on OAuth link

### DIFF
--- a/src/routes/studio/+page.server.ts
+++ b/src/routes/studio/+page.server.ts
@@ -62,6 +62,13 @@ export type ContentGroup = FlatGroup | TreeGroup;
 // ── Content tree builder ──────────────────────────────────────────────────────
 
 async function buildContentTree(collections: StudioCollection[]): Promise<ContentGroup[]> {
+	// node:fs is only available in Node.js dev server, not Cloudflare Workers
+	try {
+		await import('node:fs');
+	} catch {
+		return [];
+	}
+
 	const { readdirSync, readFileSync, statSync } = await import('node:fs');
 	const { join } = await import('node:path');
 	const { default: matter } = await import('gray-matter');

--- a/src/routes/studio/+page.server.ts
+++ b/src/routes/studio/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
+import matter from 'gray-matter';
 import { studioConfig, type StudioCollection } from '../../../studio.config';
 import { parseCFPProposals, parseCFEProposals } from '$lib/utils/csv-parser';
 import { resolveAllSessions } from '$lib/utils/sessions';
@@ -7,6 +8,17 @@ import cfpRaw from '../../../content/2026/data/cfp.csv?raw';
 import cfeRaw from '../../../content/2026/data/cfe.csv?raw';
 import cfpFeedback from '../../../content/2026/feedback/cfp.json';
 import cfeFeedback from '../../../content/2026/feedback/cfe.json';
+
+// Vite pre-bundles all studio content files at build time.
+// Works in both dev (HMR keeps it live) and Cloudflare Workers (no node:fs needed).
+const _rawMarkdown = import.meta.glob<{ default: string }>('/content/**/*.md', {
+	query: '?raw',
+	eager: true
+});
+// Normalise keys: '/content/pages/about.md' → 'content/pages/about.md'
+const markdownContent: Record<string, string> = Object.fromEntries(
+	Object.entries(_rawMarkdown).map(([p, m]) => [p.replace(/^\//, ''), m.default])
+);
 
 export interface SubmissionRow {
 	id: string;
@@ -61,39 +73,31 @@ export type ContentGroup = FlatGroup | TreeGroup;
 
 // ── Content tree builder ──────────────────────────────────────────────────────
 
-async function buildContentTree(collections: StudioCollection[]): Promise<ContentGroup[]> {
-	// node:fs is only available in Node.js dev server, not Cloudflare Workers
-	try {
-		await import('node:fs');
-	} catch {
-		return [];
-	}
-
-	const { readdirSync, readFileSync, statSync } = await import('node:fs');
-	const { join } = await import('node:path');
-	const { default: matter } = await import('gray-matter');
-
-	function getTitle(fullPath: string): string {
+function buildContentTree(collections: StudioCollection[]): ContentGroup[] {
+	function getTitle(filePath: string): string {
+		const raw = markdownContent[filePath];
+		if (!raw) return filePath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? filePath;
 		try {
-			const raw = readFileSync(fullPath, 'utf-8');
-			return matter(raw).data?.title ?? fullPath.split('/').pop() ?? fullPath;
+			return (matter(raw).data?.title as string) ?? filePath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? filePath;
 		} catch {
-			return fullPath.split('/').pop() ?? fullPath;
+			return filePath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? filePath;
 		}
 	}
 
-	function getFrontmatterField(fullPath: string, field: string): string {
+	function getFrontmatterField(filePath: string, field: string): string {
+		const raw = markdownContent[filePath];
+		if (!raw) return '';
 		try {
-			return (matter(readFileSync(fullPath, 'utf-8')).data?.[field] as string) ?? '';
+			return (matter(raw).data?.[field] as string) ?? '';
 		} catch {
 			return '';
 		}
 	}
 
-	function resolveUrl(template: string, slug: string, dirSlug: string, fullPath: string): string {
+	function resolveUrl(template: string, slug: string, dirSlug: string, filePath: string): string {
 		let url = template.replace('{dirSlug}', dirSlug).replace('{slug}', slug);
 		if (url.includes('{section}')) {
-			url = url.replace('{section}', getFrontmatterField(fullPath, 'section'));
+			url = url.replace('{section}', getFrontmatterField(filePath, 'section'));
 		}
 		// Unresolved tokens, empty trailing segment, or double slashes → no link
 		if (url.includes('{') || url.endsWith('/') || url.includes('//')) return '';
@@ -101,32 +105,23 @@ async function buildContentTree(collections: StudioCollection[]): Promise<Conten
 	}
 
 	function filesForCollection(col: StudioCollection): FileEntry[] {
-		const isMarkdown = col.type === 'markdown';
 		const dirSlug = col.path.split('/').pop() ?? '';
-		let filenames: string[] = [];
-		try {
-			filenames = readdirSync(col.path)
-				.filter((f) => {
-					try {
-						return (
-							statSync(join(col.path, f)).isFile() &&
-							!f.startsWith('.') &&
-							(!isMarkdown || f.endsWith('.md'))
-						);
-					} catch {
-						return false;
-					}
-				})
-				.sort();
-		} catch {
-			// directory missing — return empty
-		}
+		const prefix = col.path + '/';
+		const filenames = Object.keys(markdownContent)
+			.filter((p) => p.startsWith(prefix) && !p.slice(prefix.length).includes('/'))
+			.filter((p) => {
+				const f = p.slice(prefix.length);
+				return !f.startsWith('.') && f.endsWith('.md');
+			})
+			.map((p) => p.slice(prefix.length))
+			.sort();
+
 		return filenames.map((f) => {
-			const fullPath = join(col.path, f);
-			const slug = f.replace(/\.[^.]+$/, '');
-			const title = isMarkdown ? getTitle(fullPath) : f;
-			const url = col.urlTemplate ? resolveUrl(col.urlTemplate, slug, dirSlug, fullPath) : '';
-			return { title, filePath: `${col.path}/${f}`, url };
+			const filePath = `${col.path}/${f}`;
+			const slug = f.replace(/\.md$/, '');
+			const title = getTitle(filePath);
+			const url = col.urlTemplate ? resolveUrl(col.urlTemplate, slug, dirSlug, filePath) : '';
+			return { title, filePath, url };
 		});
 	}
 
@@ -179,7 +174,7 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 		.map((h: string) => h.trim())
 		.filter(Boolean);
 
-	const contentGroups = await buildContentTree(studioConfig.collections);
+	const contentGroups = buildContentTree(studioConfig.collections);
 
 	// ── Submissions + feedback ────────────────────────────────────────────────
 	type FeedbackMap = Record<string, { status?: string; notes?: string }>;

--- a/src/routes/studio/login/+page.svelte
+++ b/src/routes/studio/login/+page.svelte
@@ -20,7 +20,7 @@
 			</div>
 		{:else if data.error}
 			<div class="mb-4 rounded bg-red-50 px-4 py-3 text-sm text-red-700">
-				Sign-in failed. Please try again.
+				Sign-in failed ({data.error}). Please try again.
 			</div>
 		{/if}
 

--- a/src/routes/studio/login/+page.svelte
+++ b/src/routes/studio/login/+page.svelte
@@ -26,6 +26,7 @@
 
 		<a
 			href="/studio/auth/github"
+			data-sveltekit-reload
 			class="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-700"
 		>
 			<svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## Problems fixed

### 1. Pages and Guides empty in production
`buildContentTree` was probing `node:fs` and returning `[]` when it wasn't available (Cloudflare Workers). The studio dashboard showed no content sections after login.

**Fix:** Replace `node:fs` + dynamic imports with `import.meta.glob`. Vite pre-bundles all `content/**/*.md` files at build time as raw strings. The `buildContentTree` function reads from this pre-built map — no filesystem access needed at runtime. Works identically in dev (Vite HMR keeps glob live) and Cloudflare Workers.

### 2. "404" after logout → re-login (invalid_state on second login)
The "Sign in with GitHub" button is a plain `<a>` tag. SvelteKit intercepts link clicks and uses `fetch()` for client-side navigation. When the server returns a `302` redirect to GitHub with `Set-Cookie: oauth_state=...`, the `Set-Cookie` from a cross-origin redirect in a `fetch()` call may not be persisted by the browser before the full-page navigation to GitHub happens. On the callback, `oauth_state` cookie is absent → `invalid_state` → "Sign-in failed."

**Fix:** Add `data-sveltekit-reload` to the login link. This tells SvelteKit to do a real browser navigation (not `fetch()`), so the browser handles the `Set-Cookie` and redirect chain natively — the same path that works on the first login.

## Test plan
- [ ] Deploy to production
- [ ] Login → studio shows Pages + Guides content lists
- [ ] Logout → login again → works (no invalid_state error)
- [ ] Repeat login/logout cycle multiple times

🤖 Generated with [Claude Code](https://claude.com/claude-code)