### PR TITLE
fix(studio): handle stale staging branch causing Save Failed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,18 @@ Format: date, what changed, why, key files, notes for the next agent.
 
 ---
 
+## 2026-05-10 — fix(studio): Save Failed on stage/feedback endpoints
+
+**What changed:** Extracted `ensureStagingBranch` helper in `src/lib/studio/staging.ts` and used it in both `stage` and `feedback` API endpoints. The helper handles three cases that previously caused "Save Failed": (1) KV has a stale branch reference (branch deleted after PR merge — `getRef` now verifies the branch is still live before using it); (2) branch already exists on GitHub but KV is empty (after a same-day publish — `createRef` 422 is now caught and treated as success); (3) normal first save (unchanged).
+
+**Why:** After publishing a PR and clearing KV, if the user made another edit the same day, `createRef` threw "Reference already exists" (422) because the branch wasn't deleted yet on GitHub. This surfaced as a generic "Save Failed" error in the UI.
+
+**Key files:** `src/lib/studio/staging.ts` (new), `src/routes/api/studio/stage/+server.ts`, `src/routes/api/studio/feedback/+server.ts`
+
+**Notes for next agent:** `STUDIO_GITHUB_TOKEN` must be set as a Cloudflare secret (not in wrangler.toml). If save still fails after this fix, check that secret is configured in the CF Pages dashboard.
+
+---
+
 ## 2026-05-10 — Quality gates, changelog enforcement & faster CI
 
 **What changed:** Added pre-commit hooks via `lefthook` that run oxfmt, prettier, oxlint, and a changelog guard on staged files. Split `pnpm lint` into `lint:fmt` (oxfmt for TS/JS/JSON, ~800ms) and `lint:fmt:svelte` (prettier for Svelte/MD only). Updated CI to run both as separate steps with individual pass/fail rows in the PR comment. Added a Changelog section to `agents.md` requiring agents to update `changelog.md` before committing when source files change.

--- a/src/lib/studio/staging.ts
+++ b/src/lib/studio/staging.ts
@@ -1,0 +1,73 @@
+import type { Octokit } from '@octokit/rest';
+
+const OWNER = 'vizchitra';
+const REPO = 'vizchitra.github.io';
+const BASE_BRANCH = 'master';
+
+export interface StagingState {
+	branch: string;
+	files: string[];
+}
+
+export function stagingKey(handle: string): string {
+	return `studio_staging:${handle}`;
+}
+
+/**
+ * Returns a valid staging branch for `handle`, creating one if needed.
+ *
+ * Handles three edge cases that previously caused "Save Failed":
+ *  1. KV has a stale branch reference (branch was deleted after PR merge).
+ *  2. KV is empty but the branch already exists on GitHub (created same day,
+ *     e.g. after a publish that cleared KV but before the PR was merged).
+ *  3. Normal first-save — branch doesn't exist anywhere yet.
+ */
+export async function ensureStagingBranch(
+	octokit: Octokit,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	kv: any,
+	handle: string
+): Promise<{ branchName: string; existing: StagingState | null }> {
+	const existing = (await kv.get(stagingKey(handle), 'json')) as StagingState | null;
+
+	if (existing?.branch) {
+		// Verify the branch is still live on GitHub (may have been deleted after merge)
+		try {
+			await octokit.git.getRef({
+				owner: OWNER,
+				repo: REPO,
+				ref: `heads/${existing.branch}`
+			});
+			return { branchName: existing.branch, existing };
+		} catch {
+			// Branch gone — fall through to create a fresh one
+		}
+	}
+
+	// Determine new branch name from today's date
+	const date = new Date().toISOString().slice(0, 10);
+	const branchName = `studio/${handle}/${date}`;
+
+	// Get master HEAD SHA to base the new branch on
+	const { data: masterRef } = await octokit.git.getRef({
+		owner: OWNER,
+		repo: REPO,
+		ref: `heads/${BASE_BRANCH}`
+	});
+
+	try {
+		await octokit.git.createRef({
+			owner: OWNER,
+			repo: REPO,
+			ref: `refs/heads/${branchName}`,
+			sha: masterRef.object.sha
+		});
+	} catch (e) {
+		// 422 = branch already exists (e.g. created moments ago after a publish).
+		// That's fine — just use it.
+		const msg = e instanceof Error ? e.message : '';
+		if (!msg.includes('Reference already exists')) throw e;
+	}
+
+	return { branchName, existing: null };
+}

--- a/src/routes/api/studio/feedback/+server.ts
+++ b/src/routes/api/studio/feedback/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from './$types';
 import { Octokit } from '@octokit/rest';
+import { ensureStagingBranch, stagingKey, type StagingState } from '$lib/studio/staging';
 
 export const prerender = false;
 
@@ -11,15 +12,6 @@ type SubmissionType = 'cfp' | 'cfe';
 
 function feedbackPath(type: SubmissionType): string {
 	return `content/2026/feedback/${type}.json`;
-}
-
-function stagingKey(handle: string): string {
-	return `studio_staging:${handle}`;
-}
-
-interface StagingState {
-	branch: string;
-	files: string[];
 }
 
 interface FeedbackEntry {
@@ -77,27 +69,7 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	const repoPath = feedbackPath(type as SubmissionType);
 
 	try {
-		// Load or create staging branch
-		const existing = (await kv.get(stagingKey(handle), 'json')) as StagingState | null;
-
-		let branchName: string;
-		if (existing?.branch) {
-			branchName = existing.branch;
-		} else {
-			const date = new Date().toISOString().slice(0, 10);
-			branchName = `studio/${handle}/${date}`;
-			const { data: ref } = await octokit.git.getRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `heads/${BASE_BRANCH}`
-			});
-			await octokit.git.createRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `refs/heads/${branchName}`,
-				sha: ref.object.sha
-			});
-		}
+		const { branchName, existing } = await ensureStagingBranch(octokit, kv, handle);
 
 		// Fetch current feedback JSON from the staging branch (fall back to master)
 		let currentFeedback: Record<string, FeedbackEntry> = {};

--- a/src/routes/api/studio/stage/+server.ts
+++ b/src/routes/api/studio/stage/+server.ts
@@ -1,12 +1,12 @@
 import type { RequestHandler } from './$types';
 import { Octokit } from '@octokit/rest';
 import matter from 'gray-matter';
+import { ensureStagingBranch, stagingKey, type StagingState } from '$lib/studio/staging';
 
 export const prerender = false;
 
 const OWNER = 'vizchitra';
 const REPO = 'vizchitra.github.io';
-const BASE_BRANCH = 'master';
 
 const ALLOWED_PREFIXES = ['content/'];
 
@@ -14,16 +14,6 @@ function isAllowedPath(filePath: string): boolean {
 	const normalised = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
 	if (normalised.includes('..')) return false;
 	return ALLOWED_PREFIXES.some((prefix) => normalised.startsWith(prefix));
-}
-
-/** KV key for a user's staging state */
-function stagingKey(handle: string): string {
-	return `studio_staging:${handle}`;
-}
-
-interface StagingState {
-	branch: string;
-	files: string[];
 }
 
 export const POST: RequestHandler = async ({ request, locals, platform }) => {
@@ -76,29 +66,7 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	const content = btoa(unescape(encodeURIComponent(serialised)));
 
 	try {
-		// Load or create staging state
-		const existing = (await kv.get(stagingKey(handle), 'json')) as StagingState | null;
-
-		let branchName: string;
-
-		if (existing?.branch) {
-			branchName = existing.branch;
-		} else {
-			// Create a new staging branch
-			const date = new Date().toISOString().slice(0, 10);
-			branchName = `studio/${handle}/${date}`;
-			const { data: ref } = await octokit.git.getRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `heads/${BASE_BRANCH}`
-			});
-			await octokit.git.createRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `refs/heads/${branchName}`,
-				sha: ref.object.sha
-			});
-		}
+		const { branchName, existing } = await ensureStagingBranch(octokit, kv, handle);
 
 		// Get current file SHA on the staging branch
 		let sha: string | undefined;


### PR DESCRIPTION
## Problem

Clicking **Save** in the studio showed **"Save Failed"** on the live site.

Root cause: both the `stage` and `feedback` API endpoints had a fragile branch-resolution pattern with two failure modes:

1. **Stale KV reference** — after a PR is published and KV is cleared, then merged on GitHub (branch deleted), a later save attempt reads `null` from KV and tries to `createRef` for today's branch. If that branch was already created earlier the same day, GitHub returns 422 "Reference already exists" → unhandled → 500.

2. **Branch deleted, KV still valid** — if a branch is manually deleted or cleaned up while the KV entry still points to it, the next save tries to commit to a non-existent ref → 404 from GitHub → 500.

## Fix

Extracted a shared `ensureStagingBranch` helper in `src/lib/studio/staging.ts` used by both `stage` and `feedback` endpoints:

- If KV has a branch name, call `getRef` to verify it still exists before using it. If gone, create a fresh one.
- Wrap `createRef` in try/catch — 422 "Reference already exists" is treated as success (just use the branch).

## Note

If save still fails after this, check that `STUDIO_GITHUB_TOKEN` is set as a secret in the Cloudflare Pages dashboard (it's not in `wrangler.toml`).

## Test plan
- [ ] Save a content edit on the live site → succeeds
- [ ] Publish a PR, then immediately make another edit same day → save succeeds (branch reused)
- [ ] `pnpm check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)