### PR TITLE
fix(sessions): redirect old numbered workshop slugs from within the route

### DIFF
--- a/src/routes/2026/sessions/[slug]/+page.server.ts
+++ b/src/routes/2026/sessions/[slug]/+page.server.ts
@@ -1,7 +1,18 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, EntryGenerator } from './$types';
 import { markdownToHtml } from '$lib/utils/markdown';
 import { resolveAllSessions } from '$lib/utils/sessions';
+import redirectsRaw from '../../../../../_redirects?raw';
+
+const redirectMap = new Map<string, string>(
+	redirectsRaw
+		.split('\n')
+		.filter((line) => line.trim() && !line.startsWith('#'))
+		.flatMap((line) => {
+			const [from, to, code] = line.split(/\s+/);
+			return from && to ? [[from, to] as [string, string]] : [];
+		})
+);
 
 export const prerender = true;
 
@@ -17,6 +28,8 @@ export const load: PageServerLoad = async ({ params }) => {
 	const session = confirmed.find((s) => s.slug === params.slug);
 
 	if (!session) {
+		const target = redirectMap.get(`/2026/sessions/${params.slug}`);
+		if (target) throw redirect(301, target);
 		throw error(404, `Session "${params.slug}" not found`);
 	}
 


### PR DESCRIPTION
## Problem

Old workshop URLs like `/2026/sessions/dataviz-crash-course-without-the-crash-out-19` return 404 even though the redirect is in `_redirects`.

Root cause: `/2026/sessions/[slug]` is a more specific SvelteKit route than the top-level `[...slug]` catch-all. SvelteKit routes the request to the sessions page, which throws 404 when the slug isn't in `sessions.json`. The `_redirects` Cloudflare rule and the `[...slug]` redirect map are never reached.

## Fix

Import `_redirects` as a `?raw` Vite bundle in the sessions `[slug]/+page.server.ts`. Before throwing 404 for an unknown slug, check the redirect map for `/2026/sessions/{slug}` and redirect (301) if found.

## Test plan
- [ ] `https://vizchitra.com/2026/sessions/dataviz-crash-course-without-the-crash-out-19` → 301 to `/2026/sessions/a-dataviz-crash-course`
- [ ] All other old workshop URLs redirect correctly
- [ ] Valid session slugs still load normally
- [ ] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)