### PR TITLE
fix(redirects): handle all redirects in hooks.server before routing

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,41 +1,35 @@
 import { redirect } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { getSession } from '$lib/studio/session';
+import redirectsRaw from '../_redirects?raw';
 
-// Parse redirect paths from Cloudflare _redirects file
-// This is done once at startup in dev
-let redirects: Array<{ from: string; to: string; code: number }> = [];
-
-if (dev) {
-	try {
-		const fs = await import('node:fs');
-		const content = fs.readFileSync('_redirects', 'utf-8');
-		redirects = content
-			.split('\n')
-			.filter((line) => line.trim() && !line.startsWith('#'))
-			.map((line) => {
-				const [from, to, code] = line.split(/\s+/);
-				return { from, to, code: parseInt(code || '302', 10) };
-			});
-	} catch (e) {
-		console.warn('No _redirects file found or failed to parse');
-	}
-}
+// Parse _redirects once at module load (bundled by Vite — works in CF Workers)
+const redirectMap = new Map<string, { to: string; code: number }>(
+	redirectsRaw
+		.split('\n')
+		.filter((line) => line.trim() && !line.startsWith('#'))
+		.flatMap((line) => {
+			const [from, to, code] = line.split(/\s+/);
+			return from && to
+				? [
+						[from, { to, code: parseInt(code || '302', 10) }] as [
+							string,
+							{ to: string; code: number }
+						]
+					]
+				: [];
+		})
+);
 
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
-	// Check for redirects only in dev
-	if (dev) {
-		const path = event.url.pathname;
-		const match = redirects.find((r) => r.from === path);
-
-		if (match) {
-			throw redirect(match.code, match.to);
-		}
-	}
+	// Handle redirects in all environments — runs before routing so it catches
+	// paths that would otherwise reach prerendered-only routes and return 404.
+	const path = event.url.pathname;
+	const match = redirectMap.get(path);
+	if (match) throw redirect(match.code, match.to);
 
 	// Populate studioUser for studio + API studio routes
-	const path = event.url.pathname;
 	if (path.startsWith('/studio') || path.startsWith('/api/studio')) {
 		// In dev mode, always bypass OAuth — no env vars needed
 		const devUser = dev && (process.env.STUDIO_DEV_USER || 'dev');


### PR DESCRIPTION
## Summary
- Moves all redirect handling to `hooks.server.ts` so it runs before any routing/prerendering
- CF Pages `_redirects` wasn't firing before the SvelteKit Worker for session URLs that map to prerendered routes (returning 404)
- Uses `?raw` Vite import for `_redirects` content — works in CF Workers (no `node:fs` needed)

## Why hooks.server.ts
Routes like `/2026/sessions/[slug]` have `prerender = true`. For slugs not in the prerendered set, SvelteKit serves the prerendered 404 page — the `load` function never runs dynamically. `hooks.server.ts` runs before any routing in all environments, so redirect handling placed here catches these paths first.

## Test plan
- [ ] `curl -sI "https://vizchitra.com/2026/sessions/dataviz-crash-course-without-the-crash-out-19"` → `301` to `/2026/sessions/a-dataviz-crash-course`
- [ ] `curl -sI "https://vizchitra.com/2026/sessions/interactive-dataviz-using-ai-coding-19"` → `301` to `/2026/sessions/interactive-dataviz-using-ai-coding`
- [ ] All other existing routes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)