### PR TITLE
feat(studio): login banner, save fix, persistent panel, social previews

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,35 @@ Format: date, what changed, why, key files, notes for the next agent.
 
 ---
 
+## 2026-05-10 — feat(studio): login banner, save fix, persistent panel, social previews
+
+**What changed:**
+
+1. **Login banner** — replaced the bare centered card with a `<Hero banner="square" color="grey">` at the top + form below, matching the site aesthetic.
+2. **Save Failed fix** — `/api/studio/data` had its own inline staging-branch logic that didn't use `ensureStagingBranch()` from `staging.ts`, so the 422 "Reference already exists" fix from PR #291 never applied to session saves. Replaced with `ensureStagingBranch()`. Also fixed `SessionPanel` to surface the actual API error message instead of always showing "Save failed".
+3. **Persistent panel** — added `src/routes/+layout.server.ts` to expose `studioUser`, and a new `ViewOnlyStrip.svelte` component rendered by the root layout when logged in and no real editable panel is present. Eliminates content-shift when navigating between editable and non-editable pages.
+4. **Social preview** — added `socialImage` prop to `PanelShell`, `StudioPanel`, and `SessionPanel`. Pages pass `data.pageMeta.ogImage` to show the og:image inside the Preview section of the panel.
+
+**Why:** Studio panel was jumpy (appearing/disappearing between pages), save was broken for sessions, login page was bare.
+
+**Key files:** `src/routes/studio/login/+page.svelte`, `src/routes/api/studio/data/+server.ts`, `src/lib/studio/editor/SessionPanel.svelte`, `src/lib/studio/editor/PanelShell.svelte`, `src/lib/studio/editor/StudioPanel.svelte`, `src/lib/studio/editor/ViewOnlyStrip.svelte` (new), `src/routes/+layout.server.ts` (new), `src/routes/+layout.svelte`
+
+**Notes for next agent:** `ViewOnlyStrip` sets `panelStore` to `'collapsed'` on mount and `'hidden'` on destroy. It only renders when `data.studioUser && !pathname.startsWith('/studio') && $panelStore === 'hidden'`. The `pageMeta.ogImage` must be set in page `load()` for the social preview to appear.
+
+---
+
+## 2026-05-10 — fix(redirects): handle all redirects in hooks.server before routing (PR #294)
+
+**What changed:** Moved all `_redirects` handling into `hooks.server.ts` using a `?raw` Vite import. The hook runs before any routing, so redirects fire before SvelteKit can serve a prerendered 404 page.
+
+**Why:** Workshop session URLs with old numbered slugs (e.g. `/2026/sessions/dataviz-crash-course-without-the-crash-out-19`) were returning 404. The `/2026/sessions/[slug]` route has `prerender = true` — for slugs not in the prerendered set, SvelteKit serves the static 404 page and the `load` function never runs. CF Pages `_redirects` also didn't fire because the CF Worker handles `/*` first. `hooks.server.ts` is the only place that runs unconditionally before routing in all environments.
+
+**Key files:** `src/hooks.server.ts`
+
+**Notes for next agent:** `hooks.server.ts` is now the single runtime redirect handler (uses `?raw` Vite import — no `node:fs`). The `_redirects` file at project root is still needed for CF Pages native redirects (non-Worker paths). The redirect check in `src/routes/2026/sessions/[slug]/+page.server.ts` (from PR #293) is now redundant but harmless.
+
+---
+
 ## 2026-05-10 — fix(redirects): move \_redirects to static/ and add missing -19 entry
 
 **What changed:** Moved `_redirects` from project root to `static/` so `adapter-cloudflare` includes it in the build output (`.svelte-kit/cloudflare`). Previously the file was never deployed — all redirects were silently broken in production. Also updated `svelte.config.js` to read from `static/_redirects`. Added the missing `/2026/sessions/interactive-dataviz-using-ai-coding-19` redirect (old URL shared in workshop communications).

--- a/src/lib/studio/editor/PanelShell.svelte
+++ b/src/lib/studio/editor/PanelShell.svelte
@@ -37,6 +37,8 @@
 		children: Snippet;
 		/** Optional collapsible preview panel (card + social) */
 		preview?: Snippet;
+		/** og:image URL — shown in the preview section */
+		socialImage?: string;
 	}
 
 	let {
@@ -53,7 +55,8 @@
 		onSave,
 		onCancel,
 		children,
-		preview
+		preview,
+		socialImage
 	}: Props = $props();
 
 	// ── Collapse ─────────────────────────────────────────────────────────────
@@ -186,9 +189,9 @@
 		</div>
 
 		<!-- Optional preview (card + social) -->
-		{#if preview}
+		{#if preview || socialImage}
 			<div class="border-grey-800 border-b">
-				<details class="group">
+				<details class="group" open>
 					<summary
 						class="text-viz-grey-muted hover:text-viz-grey-light flex cursor-pointer list-none items-center justify-between px-4 py-2.5 text-[10px] font-semibold tracking-widest uppercase transition-colors"
 					>
@@ -204,8 +207,22 @@
 							<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
 						</svg>
 					</summary>
-					<div class="px-4 pb-3">
-						{@render preview()}
+					<div class="space-y-3 px-4 pb-3">
+						{#if preview}
+							{@render preview()}
+						{/if}
+						{#if socialImage}
+							<div>
+								<p class="text-viz-grey-muted mb-1.5 text-[10px] tracking-widest uppercase">
+									Social
+								</p>
+								<img
+									src={socialImage}
+									alt="Social preview"
+									class="border-grey-700 w-full rounded border object-cover"
+								/>
+							</div>
+						{/if}
 					</div>
 				</details>
 			</div>

--- a/src/lib/studio/editor/SessionPanel.svelte
+++ b/src/lib/studio/editor/SessionPanel.svelte
@@ -30,6 +30,8 @@
 		/** Long-form markdown fields edited inline on the page */
 		longDescription: string;
 		speakerAbout: string;
+		/** og:image URL for social preview */
+		socialImage?: string;
 		isEditing: boolean;
 		onStartEdit: () => void;
 		onStopEdit: () => void;
@@ -51,6 +53,7 @@
 		organisation,
 		longDescription,
 		speakerAbout,
+		socialImage,
 		isEditing,
 		onStartEdit,
 		onStopEdit,
@@ -136,7 +139,10 @@
 					}
 				})
 			});
-			if (!res.ok) throw new Error('Save failed');
+			if (!res.ok) {
+				const errBody = await res.json().catch(() => ({}));
+				throw new Error((errBody as { error?: string }).error ?? 'Save failed');
+			}
 			const result = (await res.json()) as { stagedCount?: number };
 			if (dev) {
 				saveStatus = 'saved';
@@ -182,6 +188,7 @@
 	onStartEdit={startEdit}
 	onSave={save}
 	onCancel={cancel}
+	{socialImage}
 >
 	{#snippet preview()}
 		<!-- Session card mini-preview -->

--- a/src/lib/studio/editor/StudioPanel.svelte
+++ b/src/lib/studio/editor/StudioPanel.svelte
@@ -15,9 +15,18 @@
 		getMarkdown: () => string;
 		getFrontmatter: () => Record<string, unknown>;
 		onFrontmatterChange: (updated: Record<string, unknown>) => void;
+		/** og:image URL for social preview */
+		socialImage?: string;
 	}
 
-	let { filePath, frontmatter, getMarkdown, getFrontmatter, onFrontmatterChange }: Props = $props();
+	let {
+		filePath,
+		frontmatter,
+		getMarkdown,
+		getFrontmatter,
+		onFrontmatterChange,
+		socialImage
+	}: Props = $props();
 
 	// ── Schema ───────────────────────────────────────────────────
 	const collection = $derived(collectionFromPath(filePath));
@@ -258,6 +267,37 @@
 				</span>
 			</div>
 		</div>
+
+		<!-- Social preview -->
+		{#if socialImage}
+			<div class="border-grey-800 border-b">
+				<details class="group" open>
+					<summary
+						class="text-viz-grey-muted hover:text-viz-grey-light flex cursor-pointer list-none items-center justify-between px-4 py-2.5 text-[10px] font-semibold tracking-widest uppercase transition-colors"
+					>
+						Preview
+						<svg
+							class="h-3 w-3 transition-transform group-open:rotate-180"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							aria-hidden="true"
+						>
+							<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+						</svg>
+					</summary>
+					<div class="px-4 pb-3">
+						<p class="text-viz-grey-muted mb-1.5 text-[10px] tracking-widest uppercase">Social</p>
+						<img
+							src={socialImage}
+							alt="Social preview"
+							class="border-grey-700 w-full rounded border object-cover"
+						/>
+					</div>
+				</details>
+			</div>
+		{/if}
 
 		<!-- Scrollable body: frontmatter + toolbar -->
 		<div class="flex-1 overflow-y-auto">

--- a/src/lib/studio/editor/ViewOnlyStrip.svelte
+++ b/src/lib/studio/editor/ViewOnlyStrip.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { page } from '$app/stores';
+	import { panelStore } from './PanelStore';
+
+	let collapsed = $state(true);
+
+	$effect(() => {
+		panelStore.set(collapsed ? 'collapsed' : 'open');
+	});
+	onDestroy(() => panelStore.set('hidden'));
+
+	const pathname = $derived($page.url.pathname);
+	const ogImage = $derived($page.data?.pageMeta?.ogImage as string | undefined);
+</script>
+
+{#if collapsed}
+	<button
+		type="button"
+		onclick={() => (collapsed = false)}
+		aria-label="Expand Studio panel"
+		class="border-grey-800 bg-grey-900 text-viz-grey-muted hover:text-viz-grey-light fixed top-0 right-0 z-50 flex h-full w-11 cursor-pointer flex-col items-center border-l transition-colors"
+	>
+		<span class="flex flex-col items-center gap-3 pt-4">
+			<img src="/favicon.svg" alt="" class="h-6 w-6 opacity-70" />
+			<span
+				class="text-[9px] font-semibold uppercase"
+				style="writing-mode: vertical-rl; letter-spacing: 0.4em; line-height: 1;"
+			>
+				STUDIO
+			</span>
+		</span>
+		<svg
+			class="mt-auto mb-4 h-4 w-4"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			aria-hidden="true"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+		</svg>
+	</button>
+{:else}
+	<aside
+		class="border-grey-800 bg-grey-900 text-viz-grey-light fixed top-0 right-0 z-50 flex h-full w-72 flex-col border-l"
+	>
+		<!-- Header -->
+		<div class="border-grey-800 flex items-center justify-between border-b px-4 py-3">
+			<a
+				href="/studio"
+				class="text-viz-grey-muted hover:text-viz-grey-light flex items-center gap-2 transition-colors"
+				title="Go to Studio"
+			>
+				<img src="/favicon.svg" alt="" class="h-5 w-5 opacity-70" />
+				<span class="text-xs font-semibold tracking-widest uppercase">Studio</span>
+			</a>
+			<button
+				type="button"
+				onclick={() => (collapsed = true)}
+				class="text-viz-grey-muted hover:text-viz-grey-light flex h-6 w-6 items-center justify-center rounded transition-colors"
+				aria-label="Collapse Studio panel"
+				title="Collapse panel"
+			>
+				<svg
+					class="h-4 w-4"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					aria-hidden="true"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+				</svg>
+			</button>
+		</div>
+
+		<!-- Page path -->
+		<div class="border-grey-800 border-b px-4 py-3">
+			<p class="text-viz-grey-muted mb-0.5 text-[10px] tracking-widest uppercase">Current page</p>
+			<p class="text-viz-grey-light font-mono text-sm font-medium break-all">{pathname}</p>
+		</div>
+
+		<!-- View indicator -->
+		<div class="border-grey-800 border-b px-4 py-3">
+			<span class="text-viz-grey-muted text-xs">Viewing — this page is not editable here</span>
+		</div>
+
+		<!-- Social preview -->
+		{#if ogImage}
+			<div class="border-grey-800 border-b">
+				<details class="group" open>
+					<summary
+						class="text-viz-grey-muted hover:text-viz-grey-light flex cursor-pointer list-none items-center justify-between px-4 py-2.5 text-[10px] font-semibold tracking-widest uppercase transition-colors"
+					>
+						Social Preview
+						<svg
+							class="h-3 w-3 transition-transform group-open:rotate-180"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							aria-hidden="true"
+						>
+							<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+						</svg>
+					</summary>
+					<div class="px-4 pb-3">
+						<img
+							src={ogImage}
+							alt="Social preview"
+							class="border-grey-700 w-full rounded border object-cover"
+						/>
+					</div>
+				</details>
+			</div>
+		{/if}
+
+		<!-- Go to Studio CTA -->
+		<div class="border-grey-800 mt-auto border-t px-4 py-3">
+			<a
+				href="/studio"
+				class="bg-viz-yellow text-grey-900 block w-full rounded px-3 py-2 text-center text-xs font-semibold transition-opacity hover:opacity-90"
+			>
+				Go to Studio →
+			</a>
+		</div>
+	</aside>
+{/if}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,5 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = ({ locals }) => ({
+	studioUser: locals.studioUser ?? null
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,9 +4,10 @@
 
 	import { page } from '$app/stores';
 	import { panelStore } from '$lib/studio/editor/PanelStore';
+	import ViewOnlyStrip from '$lib/studio/editor/ViewOnlyStrip.svelte';
 
-	/** @type {{children: import('svelte').Snippet}} */
-	let { children } = $props();
+	/** @type {{children: import('svelte').Snippet, data: import('./$types').LayoutData}} */
+	let { children, data } = $props();
 
 	// Layout props: new pageLayout key, falling back to old document convention during migration
 	let banner = $derived($page.data?.pageLayout?.banner ?? $page.data?.document?.banner ?? 'curve');
@@ -20,6 +21,10 @@
 </script>
 
 <SEO />
+
+{#if data.studioUser && !$page.url.pathname.startsWith('/studio') && $panelStore === 'hidden'}
+	<ViewOnlyStrip />
+{/if}
 
 <div class="app">
 	<NavMenu></NavMenu>

--- a/src/routes/2026/sessions/[slug]/+page.svelte
+++ b/src/routes/2026/sessions/[slug]/+page.svelte
@@ -143,6 +143,7 @@
 		organisation={liveOrganisation}
 		longDescription={liveDescription}
 		speakerAbout={liveSpeakerAbout}
+		socialImage={data.pageMeta?.ogImage}
 		{isEditing}
 		onStartEdit={startEdit}
 		onStopEdit={stopEdit}

--- a/src/routes/[...slug]/+page.svelte
+++ b/src/routes/[...slug]/+page.svelte
@@ -54,6 +54,7 @@
 		{getMarkdown}
 		{getFrontmatter}
 		{onFrontmatterChange}
+		socialImage={data.pageMeta?.ogImage}
 	/>
 {/if}
 

--- a/src/routes/api/studio/data/+server.ts
+++ b/src/routes/api/studio/data/+server.ts
@@ -13,6 +13,7 @@
  */
 import type { RequestHandler } from './$types';
 import { Octokit } from '@octokit/rest';
+import { ensureStagingBranch, stagingKey, type StagingState } from '$lib/studio/staging';
 
 export const prerender = false;
 
@@ -24,15 +25,6 @@ const ALLOWED_PREFIX = 'content/';
 function isAllowed(filePath: string): boolean {
 	const norm = filePath.replace(/\\/g, '/').replace(/^\/+/, '');
 	return !norm.includes('..') && norm.startsWith(ALLOWED_PREFIX) && norm.endsWith('.json');
-}
-
-function stagingKey(handle: string): string {
-	return `studio_staging:${handle}`;
-}
-
-interface StagingState {
-	branch: string;
-	files: string[];
 }
 
 export const POST: RequestHandler = async ({ request, locals, platform }) => {
@@ -83,27 +75,7 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	const repoPath = filePath.replace(/^\/+/, '');
 
 	try {
-		// Load or create staging branch
-		const existing = (await kv.get(stagingKey(handle), 'json')) as StagingState | null;
-
-		let branchName: string;
-		if (existing?.branch) {
-			branchName = existing.branch;
-		} else {
-			const date = new Date().toISOString().slice(0, 10);
-			branchName = `studio/${handle}/${date}`;
-			const { data: ref } = await octokit.git.getRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `heads/${BASE_BRANCH}`
-			});
-			await octokit.git.createRef({
-				owner: OWNER,
-				repo: REPO,
-				ref: `refs/heads/${branchName}`,
-				sha: ref.object.sha
-			});
-		}
+		const { branchName, existing } = await ensureStagingBranch(octokit, kv, handle);
 
 		// Fetch current file from staging branch (fall back to master)
 		let currentData: unknown = null;

--- a/src/routes/studio/login/+page.svelte
+++ b/src/routes/studio/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
+	import Hero from '$lib/components/structure/Hero.svelte';
 	let { data }: PageProps = $props();
 </script>
 
@@ -8,10 +9,12 @@
 	<meta name="description" content="Sign in to VizChitra Studio" />
 </svelte:head>
 
-<div class="flex min-h-screen items-center justify-center bg-gray-50">
-	<div class="w-full max-w-sm rounded-xl bg-white p-8 shadow-md">
-		<h1 class="mb-2 text-2xl font-bold text-gray-900">VizChitra Studio</h1>
-		<p class="mb-6 text-sm text-gray-500">Content editor — sign in with your GitHub account.</p>
+<Hero banner="square" color="grey" tagline="EDITORIAL STUDIO — CONTENT MANAGEMENT" />
+
+<div class="flex justify-center px-4 py-12">
+	<div class="w-full max-w-sm">
+		<h2 class="mb-1 text-xl font-bold text-gray-900">Sign in to Studio</h2>
+		<p class="mb-6 text-sm text-gray-500">Use your GitHub account to access the content editor.</p>
 
 		{#if data.error === 'unauthorized'}
 			<div class="mb-4 rounded bg-red-50 px-4 py-3 text-sm text-red-700">


### PR DESCRIPTION
## Summary
- **Login banner**: Hero component (square/grey) on login page replaces bare card layout
- **Save fix**: `/api/studio/data` had inline staging-branch code that missed the 422 fix from PR #291 — replaced with `ensureStagingBranch()`. Also fixes `SessionPanel` to surface the real API error instead of always showing "Save failed"
- **Persistent panel**: New `ViewOnlyStrip` component + root `+layout.server.ts` — when logged in and no editable panel is mounted, a collapsed strip holds the panel width so content never shifts on navigation
- **Social preview**: `socialImage` prop on `PanelShell`/`StudioPanel`/`SessionPanel` shows og:image in the Preview section; `data.pageMeta.ogImage` passed from page load

## Test plan
- [ ] `/studio/login` shows Hero banner above the sign-in card
- [ ] Edit a session on the live site → Save succeeds (no more "Save Failed")
- [ ] Navigate between `/`, `/2026`, a session page while logged in — panel strip always present, no content shift
- [ ] On a session page: Preview section shows session card + social image
- [ ] On a content page (`/test`): Preview section shows social image
- [ ] On a non-editable page (`/2026`): collapsed strip shows, expanding shows page path + og:image

🤖 Generated with [Claude Code](https://claude.com/claude-code)