### PR TITLE
chore: remove .env.example from repo, ignore all local env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-GOOGLE_SHEETS_CREDENTIALS="json-ask-aman"

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,9 @@ node_modules
 .DS_Store
 Thumbs.db
 
-# Env
+# Env — all local env files stay out of the repo; secrets live in CF Pages dashboard
 .env
 .env.*
-!.env.example
-!.env.test
 .dev.vars
 
 


### PR DESCRIPTION
All secrets live in the CF Pages dashboard. Nothing runs locally
that needs env variables, so .env.example/.dev.vars/.env have no
purpose in the repo. Removed the !.env.example gitignore exception.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
