### PR TITLE
feat(homepage): per-type session rows with sticky CallCard + horizontal scroll

### DIFF
--- a/src/lib/components/interface/CallCard.svelte
+++ b/src/lib/components/interface/CallCard.svelte
@@ -17,6 +17,10 @@
 		descriptionWidth?: string;
 		href?: string;
 		external?: boolean;
+		compact?: boolean;
+		fillHeight?: boolean;
+		selected?: boolean;
+		onclick?: () => void;
 		class?: string;
 	}
 
@@ -33,6 +37,10 @@
 		descriptionWidth,
 		href,
 		external = false,
+		compact = false,
+		fillHeight = false,
+		selected = false,
+		onclick,
 		class: className = ''
 	}: Props = $props();
 
@@ -73,10 +81,18 @@
 		yellow: 'outline-viz-yellow-muted'
 	};
 
-	const titlePositionClass = $derived(`absolute ${titlePosition}`);
+	const titlePositionClass = $derived(titlePosition);
 	const descriptionPositionClass = $derived(`absolute ${descriptionPosition}`);
 
-	const textColors: Record<Tone, string> = {
+	const titleColors: Record<Tone, string> = {
+		blue: 'text-viz-blue-dark',
+		teal: 'text-viz-teal-dark',
+		orange: 'text-viz-orange-dark',
+		pink: 'text-viz-pink-dark',
+		yellow: 'text-viz-yellow-dark'
+	};
+
+	const bodyColors: Record<Tone, string> = {
 		blue: 'text-viz-white',
 		teal: 'text-viz-black',
 		orange: 'text-viz-black',
@@ -84,8 +100,14 @@
 		yellow: 'text-viz-black'
 	};
 
+	const strokeClass = $derived(tone === 'blue' ? 'text-stroke-dark' : 'text-stroke-white');
+	const isCentered = $derived(titlePosition.includes('text-center'));
+
+	const outlineWidth = $derived(selected ? 'outline-4' : 'outline-2');
 	const containerClass = $derived(
-		`relative overflow-hidden rounded-lg aspect-[4/5] outline-2 ${borderColors[tone]} transition-all duration-200 hover:outline-4 active:outline-4 no-underline w-full min-w-[280px] sm:min-w-[320px] md:max-w-sm ${className}`
+		compact
+			? `relative overflow-hidden rounded-lg aspect-[3/4] ${outlineWidth} ${borderColors[tone]} transition-all duration-200 hover:outline-4 active:outline-4 no-underline w-full ${className}`
+			: `relative overflow-hidden rounded-lg aspect-[4/5.75] outline-2 ${borderColors[tone]} transition-all duration-200 hover:outline-4 active:outline-4 no-underline w-full ${className}`
 	);
 </script>
 
@@ -102,7 +124,7 @@
 				{tone}
 				variation={internalVariation}
 				width={400}
-				height={500}
+				height={575}
 				class="h-full w-full"
 			/>
 		</div>
@@ -116,12 +138,17 @@
 					style={titleWidth ? `width: min(${titleWidth}, calc(100% - 2rem))` : undefined}
 				>
 					<h3
-						class="font-display text-viz-black mx-1 mt-0 text-2xl leading-tight font-bold uppercase drop-shadow-lg md:text-3xl"
+						class="font-display mx-1 mt-0 text-2xl leading-tight font-bold uppercase drop-shadow-lg md:text-3xl {titleColors[
+							tone
+						]}"
 					>
 						{title}
 					</h3>
 					{#if subtitle}
-						<p class="text-viz-black mx-1 mt-0 text-lg leading-tight drop-shadow-md md:text-xl">
+						<p
+							class="text-viz-black mx-1 mt-0 max-w-[12ch] text-lg leading-tight md:text-2xl"
+							class:mx-auto={isCentered}
+						>
 							{subtitle}
 						</p>
 					{/if}
@@ -136,11 +163,7 @@
 						? `width: min(${descriptionWidth}, calc(100% - 2rem))`
 						: undefined}
 				>
-					<p
-						class="font-body text-md mx-1 mt-0 leading-[1.1] italic drop-shadow-md {textColors[
-							tone
-						]}"
-					>
+					<p class="font-body {strokeClass} mx-1 mt-0 text-lg leading-tight {bodyColors[tone]}">
 						{description}
 					</p>
 				</div>
@@ -155,9 +178,32 @@
 		target={external ? '_blank' : undefined}
 		rel={external ? 'noopener noreferrer' : undefined}
 		class="block no-underline"
+		{onclick}
 	>
 		{@render cardContent()}
 	</a>
+{:else if onclick}
+	<button type="button" class="block w-full cursor-pointer border-0 bg-transparent p-0" {onclick}>
+		{@render cardContent()}
+	</button>
 {:else}
 	{@render cardContent()}
 {/if}
+
+<style>
+	.text-stroke-white {
+		text-shadow:
+			-1.5px -1.5px 0 white,
+			1.5px -1.5px 0 white,
+			-1.5px 1.5px 0 white,
+			1.5px 1.5px 0 white;
+	}
+
+	.text-stroke-dark {
+		text-shadow:
+			-1.5px -1.5px 0 #1a1a2e,
+			1.5px -1.5px 0 #1a1a2e,
+			-1.5px 1.5px 0 #1a1a2e,
+			1.5px 1.5px 0 #1a1a2e;
+	}
+</style>

--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -186,7 +186,7 @@
 	<div class="sessions-card-wrapper group relative mx-auto w-full">
 		<a
 			href={detailHref}
-			class="sessions-card white border-viz-grey/40 isolate block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] group-hover:scale-102"
+			class="sessions-card bg-viz-white border-viz-grey/40 isolate block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] group-hover:scale-102"
 			onpointermove={handlePointerMove}
 			onpointerleave={handlePointerLeave}
 		>

--- a/src/routes/2026/+page.svelte
+++ b/src/routes/2026/+page.svelte
@@ -22,7 +22,147 @@
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	const typeOrder = ['Workshops', 'Talks', 'Dialogues', 'Exhibition'];
+
+	const sessionGroups = $derived(
+		typeOrder
+			.map((type) => ({
+				type,
+				sessions: data.selectedSessions.filter((s) => s.sessionType === type)
+			}))
+			.filter((g) => g.sessions.length > 0)
+	);
+
+	type Pattern = 'circle' | 'waves' | 'river' | 'stream';
+	type Tone = 'blue' | 'teal' | 'orange' | 'pink' | 'yellow';
+
+	const typeConfig: Record<
+		string,
+		{
+			pattern: Pattern;
+			tone: Tone;
+			titlePosition: string;
+			href: string;
+			subtitle: string;
+			description: string;
+			descriptionPosition: string;
+			descriptionWidth: string;
+		}
+	> = {
+		Workshops: {
+			pattern: 'circle',
+			tone: 'pink',
+			titlePosition: 'pt-40 text-center',
+			href: '/2026/workshops',
+			subtitle: 'The Learning Journey',
+			description:
+				'Half-day, hands-on sessions with expert facilitators. Skill-building & learning through doing.',
+			descriptionPosition: 'bottom-5 left-1/2 -translate-x-1/2 text-center',
+			descriptionWidth: '30ch'
+		},
+		Talks: {
+			pattern: 'waves',
+			tone: 'blue',
+			titlePosition: 'pt-2 text-left',
+			href: '/2026/talks',
+			subtitle: 'The Narrative Journey',
+			description:
+				'Deep dives into projects & lived experiences. Stories that reshape how we see our viz work.',
+			descriptionPosition: 'bottom-5 left-8 text-left',
+			descriptionWidth: '30ch'
+		},
+		Dialogues: {
+			pattern: 'river',
+			tone: 'teal',
+			titlePosition: 'pt-12 text-left',
+			href: '/2026/dialogues',
+			subtitle: 'The Shared Journey',
+			description:
+				'Participant-driven, unconference-style sessions. Meaning that emerges through conversation.',
+			descriptionPosition: 'top-48 left-8 text-left',
+			descriptionWidth: '20ch'
+		},
+		Exhibition: {
+			pattern: 'stream',
+			tone: 'orange',
+			titlePosition: 'pt-4 text-center',
+			href: '/2026/exhibition',
+			subtitle: 'The Immersive Journey',
+			description:
+				'Data, Otherwise: a curated gallery on climate & ecology viz. Works that slow you down & feel.',
+			descriptionPosition: 'bottom-2 left-1/2 -translate-x-1/2 text-center',
+			descriptionWidth: '20ch'
+		}
+	};
+
+	// Scroll tracking — one entry per type
+	let activeIndex: Record<string, number> = $state({ Workshops: 0, Talks: 0, Dialogues: 0 });
+
+	function handleScroll(type: string, el: HTMLElement) {
+		const card = el.querySelector<HTMLElement>('.session-card-wrap');
+		if (!card) return;
+		activeIndex[type] = Math.round(el.scrollLeft / card.offsetWidth);
+	}
 </script>
+
+{#snippet sessionRow(type: string)}
+	{@const group = sessionGroups.find((g) => g.type === type)}
+	{#if group}
+		{@const cfg = typeConfig[type]}
+		<FullBleed paddingX="md">
+			<!-- Dots row: thin strip above, offset to align with session cards -->
+			<div class="dots-row">
+				{#each group.sessions as _, i}
+					<span class="dot" class:dot-active={activeIndex[type] === i}></span>
+				{/each}
+			</div>
+			<div class="type-row" onscroll={(e) => handleScroll(type, e.currentTarget as HTMLElement)}>
+				<!-- Fixed left CallCard (sticky on desktop, scrolls on mobile) -->
+				<div class="type-label">
+					<CallCard
+						title={group.type}
+						subtitle={cfg.subtitle}
+						description={cfg.description}
+						pattern={cfg.pattern}
+						tone={cfg.tone}
+						titlePosition={cfg.titlePosition}
+						descriptionPosition={cfg.descriptionPosition}
+						descriptionWidth={cfg.descriptionWidth}
+						href={cfg.href}
+						variation={0.5}
+					/>
+				</div>
+				<div
+					class="sessions-scroll"
+					onscroll={(e) => handleScroll(type, e.currentTarget as HTMLElement)}
+				>
+					{#each group.sessions as session (session.slug)}
+						<div class="session-card-wrap">
+							<SessionCardExpanded
+								title={session.title}
+								speakerName={session.speakerName}
+								designation={session.designation}
+								organisation={session.organisation}
+								sessionType={session.sessionType}
+								subtitle={session.subtitle}
+								date={session.date}
+								time={session.time}
+								slot={session.slot}
+								venue={session.venue}
+								slug={session.slug}
+								speakerImage={session.speakerImage}
+								tbd={session.tbd}
+								isExpanded={true}
+								descriptionHtml={session.descriptionHtml}
+							/>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</FullBleed>
+	{/if}
+{/snippet}
 
 <Hero banner="spinner" />
 
@@ -39,139 +179,52 @@
 			and connecting with the data visualization community.
 		</Text>
 
-		<!-- <Cluster justify="start">
-			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>
-				Get your Tickets now!
-			</Button>
-		</Cluster> -->
+		<Cluster justify="start" class="pt-8">
+			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>Get Tickets</Button>
+			<Button href="/2026/sessions" color="pink">See all Sessions</Button>
+		</Cluster>
 
 		<DividerCurves />
 
 		<!-- ── What's On ─────────────────────────────────────────────────── -->
 
-		<Heading tag="h2" class="font-normal">
+		<!-- <Heading tag="h2" class="font-normal">
 			<Slanted color="pink" textContent="WHAT'S ON" />
-		</Heading>
+		</Heading> -->
 
-		<Text>
-			<ColorSpan color="black">Workshop Day on July 3<sup>rd</sup>, 2026 (Friday)</ColorSpan>: Three
-			hours, hands-on
-			<ColorSpan color="pink">Workshop</ColorSpan> facilitated by leading practitioners at Bangalore International
-			Centre (BIC) & Underline Center.
-		</Text>
-		<Text type="body">
-			<ColorSpan color="black">Conference Day on July 4<sup>th</sup>, 2026 (Saturday)</ColorSpan>:
-			Full day of sessions including
-			<ColorSpan color="blue">Talks</ColorSpan>,
-			<ColorSpan color="teal">Dialogues</ColorSpan>, and the
-			<ColorSpan color="orange">Exhibition</ColorSpan> at Bangalore International Centre (BIC), Bengaluru.
-		</Text>
-
-		<Cluster justify="start" class="pt-8">
-			<Button href="https://tickets.vizchitra.com" color="pink" external={true}>Get Tickets</Button>
-		</Cluster>
-
-		<CursorHint>Click on the cards to learn more</CursorHint>
-
-		<FullBleed>
-			<Cluster>
-				<Stack>
-					<CallCard
-						title="Workshops"
-						subtitle="The Learning Journey"
-						description="Half-day, hands-on sessions with expert facilitators. Skill-building & learning through doing."
-						pattern="circle"
-						tone="pink"
-						titlePosition="top-32 left-1/2 -translate-x-1/2 text-center"
-						descriptionPosition="bottom-2 left-1/2 -translate-x-1/2 text-center"
-						descriptionWidth="30ch"
-						href="/2026/workshops"
-						variation={0.5}
-					/>
-				</Stack>
-				<Stack>
-					<CallCard
-						title="Talks"
-						subtitle="The Narrative Journey"
-						description="Deep dives into projects & lived experiences. Stories that reshape how we see our viz work."
-						pattern="waves"
-						tone="blue"
-						titlePosition="top-5 left-3 text-left"
-						titleWidth="15ch"
-						descriptionPosition="bottom-2 left-3 text-left"
-						descriptionWidth="30ch"
-						href="/2026"
-					/>
-				</Stack>
-				<Stack>
-					<CallCard
-						title="Dialogues"
-						subtitle="The Shared Journey"
-						description="Participant-driven, unconference-style sessions. Meaning that emerges through conversation."
-						pattern="river"
-						tone="teal"
-						titlePosition="top-18 left-3 text-left"
-						descriptionPosition="top-37 left-3 text-left"
-						descriptionWidth="16ch"
-						href="/2026"
-					/>
-				</Stack>
-				<Stack>
-					<CallCard
-						title="Exhibition"
-						subtitle="The Immersive Journey"
-						description="Data, Otherwise: a curated gallery on climate & ecology viz. Works that slow you down & feel."
-						pattern="stream"
-						tone="orange"
-						titlePosition="top-5 left-1/2 -translate-x-1/2 text-center"
-						titleWidth="30ch"
-						descriptionPosition="bottom-2 left-1/2 -translate-x-1/2 text-center"
-						descriptionWidth="30ch"
-						href="/2026"
-					/>
-				</Stack>
-			</Cluster>
-		</FullBleed>
+		<!-- Workshop Day -->
+		<Stack>
+			<Heading tag="h2" class="font-normal">
+				<Slanted color="pink" textContent="WORKSHOP DAY" />
+				<span> on Friday, 03 July 2026</span>
+			</Heading>
+			<Text>
+				<!-- <ColorSpan color="black">Workshop Day on July 3<sup>rd</sup>, 2026 (Friday)</ColorSpan>: -->
+				Three hours, hands-on
+				<ColorSpan color="pink">Workshop</ColorSpan> facilitated by leading practitioners at Bangalore
+				International Centre (BIC) & Underline Center.
+			</Text>
+			{@render sessionRow('Workshops')}
+		</Stack>
 
 		<DividerCurves />
 
-		{#if data.selectedSessions.length > 0}
+		<!-- Conference Day -->
+		<Stack>
 			<Heading tag="h2" class="font-normal">
-				<Slanted color="pink" textContent="TAKING SHAPE: Confimed Sessions" />
+				<Slanted color="pink" textContent="CONFERENCE DAY" />
+				<span> on Saturday, 04 July 2026</span>
 			</Heading>
-
-			<Text type="body"
-				>The lineup is taking shape for VizChitra 2026. Here's a first look at the Workshop
-				Sessions. More to come soon.</Text
-			>
-			<Cluster justify="start">
-				<Button href="/2026/sessions" color="pink">View all Sessions</Button>
-			</Cluster>
-
-			<FullBleed paddingX="md">
-				<div class="sessions-grid mx-auto w-full justify-center gap-6">
-					{#each data.selectedSessions as session (session.slug)}
-						<SessionCardExpanded
-							title={session.title}
-							speakerName={session.speakerName}
-							designation={session.designation}
-							organisation={session.organisation}
-							sessionType={session.sessionType}
-							subtitle={session.subtitle}
-							date={session.date}
-							time={session.time}
-							slot={session.slot}
-							venue={session.venue}
-							slug={session.slug}
-							speakerImage={session.speakerImage}
-							tbd={session.tbd}
-							isExpanded={false}
-							descriptionHtml={session.descriptionHtml}
-						/>
-					{/each}
-				</div>
-			</FullBleed>
-		{/if}
+			<Text type="body">
+				<!-- <ColorSpan color="black">Conference Day on July 4<sup>th</sup>, 2026 (Saturday)</ColorSpan>: -->
+				Full day of sessions including
+				<ColorSpan color="blue">Talks</ColorSpan>,
+				<ColorSpan color="teal">Dialogues</ColorSpan>, and the
+				<ColorSpan color="orange">Exhibition</ColorSpan> at Bangalore International Centre (BIC), Bengaluru.
+			</Text>
+			{@render sessionRow('Talks')}
+			{@render sessionRow('Dialogues')}
+		</Stack>
 
 		<!-- ── Browse Submissions ─────────────────────────────────────────── -->
 
@@ -189,26 +242,6 @@
 			2026. You can explore all the submitted proposals below.
 		</Text>
 
-		<!-- <Cluster justify="start">
-			<Button href="/2026/proposals" color="pink">Submit your Proposal</Button>
-			<Button href="/2026/exhibition" color="orange">Submit for Exhibition</Button>
-		</Cluster>
-
-		<Text type="caption">
-			Submission Deadline: <strong>15 Feb 2025, 23:59 IST</strong>.
-		</Text>
-
-		<DividerCurves />
-
-		<Heading tag="h3" class="font-normal">
-			<Slanted color="blue" textContent="BROWSE SUBMISSIONS" />
-		</Heading>
-
-		<Text type="body">
-			Explore all submitted proposals for VizChitra 2026. Browse talks, dialogues, workshops, and
-			exhibitions from our community.
-		</Text> -->
-
 		<Cluster justify="start">
 			<Button href="/2026/submissions" color="blue">View all Submissions</Button>
 		</Cluster>
@@ -216,21 +249,112 @@
 </Container>
 
 <style>
-	.sessions-grid {
-		display: grid;
-		max-width: 1440px;
-		grid-template-columns: repeat(3, minmax(320px, 450px));
+	/* ── Desktop layout ─────────────────────────────────────────────── */
+
+	.type-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 0;
 	}
 
-	@media (max-width: 1600px) {
-		.sessions-grid {
-			grid-template-columns: repeat(2, minmax(320px, 500px));
+	.type-label {
+		flex: none;
+		width: 360px;
+		position: sticky;
+		left: 0;
+		z-index: 10;
+	}
+
+	.dots-row {
+		display: flex;
+		gap: 6px;
+		padding: 4px 0 6px;
+		margin-left: 376px; /* 360px label + 16px sessions-scroll padding */
+	}
+
+	.dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: #ccc;
+		flex-shrink: 0;
+		transition: background 300ms ease;
+	}
+
+	.dot-active {
+		background: #444;
+	}
+
+	.sessions-scroll {
+		display: flex;
+		overflow-x: auto;
+		padding-bottom: 0.75rem;
+		padding-left: 16px;
+		padding-right: 2rem;
+		scroll-snap-type: x mandatory;
+		scroll-padding-left: 16px;
+		/* hide scrollbar */
+		scrollbar-width: none;
+	}
+
+	.sessions-scroll::-webkit-scrollbar {
+		display: none;
+	}
+
+	.session-card-wrap {
+		flex: none;
+		width: 360px;
+		margin-left: -48px;
+		scroll-snap-align: start;
+		transition: margin 500ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	.session-card-wrap:first-child {
+		margin-left: 0;
+	}
+
+	.sessions-scroll:hover .session-card-wrap:not(:first-child),
+	.sessions-scroll:focus-within .session-card-wrap:not(:first-child) {
+		margin-left: 8px;
+	}
+
+	/* ── Mobile layout ──────────────────────────────────────────────── */
+
+	@media (max-width: 768px) {
+		/* The whole row scrolls — CallCard becomes the first scrollable card */
+		.type-row {
+			overflow-x: auto;
+			scroll-snap-type: x mandatory;
+			scrollbar-width: none;
 		}
-	}
 
-	@media (max-width: 850px) {
-		.sessions-grid {
-			grid-template-columns: repeat(1, minmax(300px, 500px));
+		.type-row::-webkit-scrollbar {
+			display: none;
+		}
+
+		.type-label {
+			position: static;
+			width: 280px;
+			z-index: auto;
+			scroll-snap-align: start;
+			flex-shrink: 0;
+		}
+
+		.dots-row {
+			margin-left: 0;
+		}
+
+		.sessions-scroll {
+			display: contents;
+		}
+
+		.session-card-wrap {
+			width: 280px;
+			margin-left: 8px;
+		}
+
+		.session-card-wrap:first-child {
+			margin-left: 8px;
 		}
 	}
 </style>

--- a/src/routes/2026/sessions/+page.svelte
+++ b/src/routes/2026/sessions/+page.svelte
@@ -17,13 +17,19 @@
 
 	const days = [
 		{ label: 'All Days', value: 'all' },
-		{ label: 'Workshop Day — 03 Jul', value: '2026-07-03' },
-		{ label: 'Conference Day — 04 Jul', value: '2026-07-04' }
+		{ label: 'Workshop Day — 03 Jul', value: 'workshop' },
+		{ label: 'Conference Day — 04 Jul', value: 'conference' }
 	];
+
+	const dayDateMap: Record<string, string> = {
+		workshop: '2026-07-03',
+		conference: '2026-07-04'
+	};
 
 	let filteredSessions = $derived(
 		data.sessions.filter((s) => {
-			const matchesDay = selectedDay === 'all' || s.date.startsWith(selectedDay);
+			const datePrefix = dayDateMap[selectedDay] ?? selectedDay;
+			const matchesDay = selectedDay === 'all' || s.date.startsWith(datePrefix);
 			const matchesFormat = selectedFormat === 'all' || s.sessionType === selectedFormat;
 			return matchesDay && matchesFormat;
 		})
@@ -98,13 +104,6 @@
 					{format}
 				</button>
 			{/each}
-
-			<span class="text-viz-grey/50 ml-auto text-sm">
-				{filteredSessions.filter((s) => !s.tbd).length} confirmed ·
-				{#if filteredSessions.filter((s) => s.tbd).length > 0}
-					{filteredSessions.filter((s) => s.tbd).length} coming soon
-				{/if}
-			</span>
 		</div>
 
 		<!-- Session cards grid -->


### PR DESCRIPTION
## Summary
- Each session type (Workshops, Talks, Dialogues) gets its own distinct row on the `/2026` homepage
- Left side: sticky `CallCard` linking to the type's page (pattern/tone/description per type)
- Right side: horizontally-scrolling session cards with overlap fan-out animation on hover
- Dot indicators above each row track scroll position
- Mobile/iPad (≤768px): CallCard scrolls inline as first card in the flat row

## Changes
- `src/routes/2026/+page.svelte` — complete redesign with per-type row layout, scroll tracking, dot indicators
- `src/lib/components/interface/CallCard.svelte` — tone-colored titles, body color by tone, text-stroke on description, flow-based title positioning, `compact`/`selected`/`onclick` props
- `src/lib/components/sessions/SessionCardExpanded.svelte` — added `bg-viz-white` background

## Test plan
- [ ] Desktop: three rows visible, sticky CallCard on left, session cards scroll right with overlap → fan-out on hover
- [ ] Mobile: all cards (including CallCard) scroll horizontally in a flat row
- [ ] Dots update as you scroll each row
- [ ] CallCard links navigate to correct type pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)