### PR TITLE
fix(studio): set og:image via pageMeta for /studio and /studio/login

### DIFF
--- a/src/routes/studio/+page.server.ts
+++ b/src/routes/studio/+page.server.ts
@@ -291,7 +291,8 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 		cfeGroups,
 		pageMeta: {
 			title: 'Studio',
-			description: 'VizChitra content editor'
+			description: 'VizChitra content editor',
+			ogImage: '/images/preview/preview-studio.jpg'
 		}
 	};
 };

--- a/src/routes/studio/+page.svelte
+++ b/src/routes/studio/+page.svelte
@@ -58,9 +58,6 @@
 <svelte:head>
 	<title>Studio | VizChitra</title>
 	<meta name="description" content="VizChitra Studio" />
-	<meta property="og:image" content="/images/preview/preview-studio.jpg" />
-	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:image" content="/images/preview/preview-studio.jpg" />
 </svelte:head>
 
 <div class="bg-grey-950 min-h-screen">

--- a/src/routes/studio/login/+page.server.ts
+++ b/src/routes/studio/login/+page.server.ts
@@ -9,6 +9,11 @@ export const load: PageServerLoad = ({ locals, url }) => {
 	}
 
 	return {
-		error: url.searchParams.get('error') ?? null
+		error: url.searchParams.get('error') ?? null,
+		pageMeta: {
+			title: 'Studio Login',
+			description: 'Sign in to VizChitra Studio',
+			ogImage: '/images/preview/preview-studio.jpg'
+		}
 	};
 };

--- a/src/routes/studio/login/+page.svelte
+++ b/src/routes/studio/login/+page.svelte
@@ -8,9 +8,6 @@
 <svelte:head>
 	<title>Studio Login | VizChitra</title>
 	<meta name="description" content="Sign in to VizChitra Studio" />
-	<meta property="og:image" content="/images/preview/preview-studio.jpg" />
-	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:image" content="/images/preview/preview-studio.jpg" />
 </svelte:head>
 
 <Header banner="square" color="grey" />


### PR DESCRIPTION
## Summary
- Move og:image to `pageMeta.ogImage` in both `+page.server.ts` files so the root layout's `<SEO />` component renders it correctly
- Remove the duplicate manual og meta tags from both pages' `<svelte:head>` blocks

The previous approach of setting `<meta property="og:image">` inline was being overridden by the `<SEO />` component which always renders the default image when `pageMeta.ogImage` is absent.

## Test plan
- [ ] Paste `/studio` and `/studio/login` into a social preview tool — both should show `preview-studio.jpg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)