### PR TITLE
fix(sessions): update redirect for dataviz crash course workshop

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -14,7 +14,7 @@
 
 /2026/sessions/from-tables-to-maps-14 /2026/sessions/from-tables-to-maps 301
 /2026/sessions/draw-with-data-15 /2026/sessions/draw-with-data 301
-/2026/sessions/dataviz-crash-course-without-the-crash-out-19 /2026/sessions/a-dataviz-crash-course 301
+/2026/sessions/a-dataviz-crash-course-16 /2026/sessions/a-dataviz-crash-course 301
 /2026/sessions/data-rough-17 /2026/sessions/data-rough 301
 /2026/sessions/observe-collect-map-18 /2026/sessions/observe-collect-map 301
 /2026/sessions/interactive-dataviz-using-ai-coding-19 /2026/sessions/interactive-dataviz-using-ai-coding 301


### PR DESCRIPTION
heyo, love the idea of the conf and how it's shaping up! I was trying to register and spotted a small bug where the dataviz crash course's workshop page link on the website would 404. I tweaked the URL and ended up on the right page, so thought of quickly looking up the code to let everyone know or raise a quick fix. I later realised that it was a redirects issue instead, so here's that small fix!

hope it turns out to be a wonderful event!