### PR TITLE
Fix encoding issues in sessions copy

### DIFF
--- a/content/2026/data/sessions.toml
+++ b/content/2026/data/sessions.toml
@@ -55,7 +55,7 @@ organisation = "Bengawalk"
 speakerAbout = """
 Shubhra Agarwal is a multidisciplinary designer and filmmaker working at the intersection of people, culture and planet. Shubhra graduated from the National Institute of Design, Ahmedabad, India and works on visual design, web design, data viz and filmmaking projects.&#x20;
 
-Their award-winning short film 'Ã§ÂÂ«Ã§ÂÂ°Ã¥Â±Â±Ã§ÂÂÃ¤ÂºÂºÃ¤Â»Â¬ People of the Flaming Mountain', one of the only films on Chinese Uighur Muslims, is recognised and celebrated across the globe. Shubhra believes that the goal informs medium, not the other way around, and uses both design and film to achieve it. Their recent interests include public transit signage, birding and travel-food memoirs.
+Their award-winning short film '火焰山的人们 People of the Flaming Mountain', one of the only films on Chinese Uighur Muslims, is recognised and celebrated across the globe. Shubhra believes that the goal informs medium, not the other way around, and uses both design and film to achieve it. Their recent interests include public transit signage, birding and travel-food memoirs.
 """
 speakerImage = "/images/speakers/2026/speaker-shubhra.avif"
 display = true

--- a/content/2026/data/sessions.toml
+++ b/content/2026/data/sessions.toml
@@ -25,7 +25,7 @@ speakerName = "Saurabh Arora"
 designation = "Chief Technology Officer"
 organisation = "Plum"
 speakerAbout = """
-Saurabh is the cofounder and CTO of Plum, where he leads Engineering, Product, and Design. Plum processes over 125,000 health insurance claims every year Ã¢ÂÂ and Saurabh wanted that data to do more than sit in spreadsheets. He created Datalabs, an initiative that turns claims data into interactive visual investigations about cost of healthcare. Their stories on cancer costs and heart disease burden have combined rigorous analysis with accessible narrative design to make complex health economics legible to anyone. Saurabh is interested in the craft of making the intimidating feel approachable, and the invisible feel urgent."""
+Saurabh is the cofounder and CTO of Plum, where he leads Engineering, Product, and Design. Plum processes over 125,000 health insurance claims every year — and Saurabh wanted that data to do more than sit in spreadsheets. He created Datalabs, an initiative that turns claims data into interactive visual investigations about cost of healthcare. Their stories on cancer costs and heart disease burden have combined rigorous analysis with accessible narrative design to make complex health economics legible to anyone. Saurabh is interested in the craft of making the intimidating feel approachable, and the invisible feel urgent."""
 speakerImage = "/images/speakers/2026/speaker-saurabh.avif"
 display = true
 order = 6
@@ -420,9 +420,9 @@ speakerName = "Rohit Saran"
 designation = "Managing Editor"
 organisation = "The Times of India"
 speakerAbout = """
-Rohit Saran is the Managing Editor of The Times of India. He has served as Executive Editor of The Times of India, The Economic Times, and India Today, and was Editor-in-Chief of Business Today and Khaleej Times. Since the 1990s, he has practised data and visual journalism across leading newsroomsÃ¢ÂÂblending numbers, visuals, and text to tell richer stories and to create enduring news products.
+Rohit Saran is the Managing Editor of The Times of India. He has served as Executive Editor of The Times of India, The Economic Times, and India Today, and was Editor-in-Chief of Business Today and Khaleej Times. Since the 1990s, he has practised data and visual journalism across leading newsrooms — blending numbers, visuals, and text to tell richer stories and to create enduring news products.
 
-Rohit teamed up with Sajeev Kumarapuram, Design Editor of The Times of India to author '100 Ways to See India -- Stats, Stories and Surprises' which was published by Harper Collins India earlier this year. Rohit and Sajeev have spent years exploring India's data jungleÃ¢ÂÂmostly out of professional need, at times out of curiosity. Along the way, they've hunted elusive numbers, dodged PDF traps, and found joy in telling stories through charts."""
+Rohit teamed up with Sajeev Kumarapuram, Design Editor of The Times of India to author '100 Ways to See India -- Stats, Stories and Surprises' which was published by Harper Collins India earlier this year. Rohit and Sajeev have spent years exploring India's data jungle—mostly out of professional need, at times out of curiosity. Along the way, they've hunted elusive numbers, dodged PDF traps, and found joy in telling stories through charts."""
 speakerImage = "/images/speakers/2026/speaker-rohit-saran.webp"
 display = true
 order = 2
@@ -634,7 +634,7 @@ speakerName = "Agriya Khetarpal"
 designation = "Software Engineer"
 organisation = "Quansight"
 speakerAbout = """
-Agriya is a software engineer at Quansight, where he works on scientific open source software in the Scientific Python and Jupyter ecosystems. He is passionate about advancing science policy in India and believes that data, communicated honestly and rigorously, is one of its most powerful tools Ã¢ÂÂ a conviction that keeps him equally at home, whether in a terminal or in a policy debate."""
+Agriya is a software engineer at Quansight, where he works on scientific open source software in the Scientific Python and Jupyter ecosystems. He is passionate about advancing science policy in India and believes that data, communicated honestly and rigorously, is one of its most powerful tools – a conviction that keeps him equally at home, whether in a terminal or in a policy debate."""
 speakerImage = "/images/speakers/2026/speaker-agriya.avif"
 display = true
 order = 17
@@ -804,7 +804,7 @@ order = 22
 slug = "draw-with-data"
 sessionType = "Workshops"
 date = "2026-07-03"
-time = "10:00 Ã¢ÂÂ 13:00"
+time = "10:00 – 13:00"
 slot = "morning"
 venue = "Underline Center"
 title = "Draw with Data: Custom Dataviz Using D3"


### PR DESCRIPTION
Fix a couple em dashes and quotes in the sessions details where encoding seemed to be broken.