### PR TITLE
Fix sold-out ribbon + update talk descriptions

### DIFF
--- a/content/2026/data/sessions.toml
+++ b/content/2026/data/sessions.toml
@@ -94,16 +94,26 @@ display = true
 order = 8
 
 [[session]]
-slug = "chart-triplet"
+slug = "caption-this"
 sessionType = "Talks"
 date = "2026-07-04"
 time = "11:15 - 11:45"
 slot = "morning"
 venue = "Bangalore International Centre"
-title = "The Chart Triplet: Represent & Curate"
-subtitle = "A chart is its pixels, its spec, and its insight. Can a machine learn all three at once?"
-shortDescription = "Every chart has three faces: the visual, the declarative spec, and the insight it carries. This talk tests whether a machine can learn to move between all three, and whether that solves the harder problem of generating visualizations worth keeping."
-longDescription = "A good chart compresses data. A good insight compresses the chart. This chain of lossy compressions, from dataset to visual to meaning, is what data visualization is fundamentally about.\n\nThe question Jaidev has been working on is whether a machine can learn to do it well.\n\nHis hypothesis is that the three elements of any chart, the raw pixels, the declarative specification in a language like Vega, and the insights or captions drawn from it, are not three separate things. They are one thing seen from three angles. He calls this the chart triplet. A skilled analyst with any one of the three can construct reasonable approximations of the other two. The question is whether a machine can learn to do the same.\n\nThis talk walks through a series of experiments testing that hypothesis: building dense, unified representations of the chart triplet, training visual and language transformer models to navigate between pixels, specs, and insights, and evaluating whether the outputs clear the bar from generated to genuinely useful.\n\nThe problem this is ultimately trying to solve is not generation. LLMs can already build charts. The problem is curation: distinguishing the chart worth shipping from the nine others that are technically fine. Jaidev's bet is that a meaningful representation of the chart triplet is what makes that distinction learnable.\n\nBefore the talk, he will release an open dataset of over 1,50,000 charts, each with its Vega spec and a million accompanying captions, along with all code and trained models.\n"
+title = "Caption This: Teaching Machines to Narrate Charts"
+subtitle = "Generating captions is easy. Curating the right one is not. Can machines learn the difference?"
+shortDescription = "A chart compresses data. A caption compresses the chart. This talk explores whether machines can learn that second compression well, and why generation turns out to be the easy part."
+longDescription = """
+Every chart is a chain of compressions. A dataset becomes a visual. A visual becomes an insight. Each step throws away information deliberately, keeping only what matters. The last step, turning a chart into a caption worth reading, is the hardest. And it is the one that language models handle worst.
+
+Jaidev has spent the last year trying to fix that. Not by generating more captions, which turns out to be straightforward, but by figuring out how to curate the right one. The problem is that a model can produce dozens of plausible captions for any chart. Knowing which one is accurate, useful, and meant for this audience, in this context, still takes a human.
+
+His response is an extended PlotCaptions: an open dataset of over 150,000 charts with accompanying captions, built to serve two purposes. First, as a retrieval corpus to ground generation, giving models precedent rather than asking them to guess. Second, as a record of human judgment about what good captions look like, used to train ranking.
+
+The pipeline that emerges is straightforward: retrieve similar charts and their best captions, generate candidates, rank against what humans have consistently preferred. This talk walks through what that system gets right, what it still gets wrong, and where the curation gap remains open.
+
+The dataset, code, and trained models will be released before the talk. The audience is invited to use them, test them, and beat the benchmarks.
+"""
 speakerName = "Jaidev Deshpande"
 designation = "Senior Software Engineer"
 organisation = "Aftershoot"
@@ -159,8 +169,19 @@ slot = "morning"
 venue = "Bangalore International Centre"
 title = "Atlas of Intangibles"
 subtitle = "The senses hold data too. Mapped across cities, one walk at a time."
-shortDescription = "A place is more than coordinates. This talk traces the process behind data experiences rooted in sensory information: visual ethnography, score-based data walks, and collective mapping that helps us connect more deeply with the places we inhabit."
-longDescription = "Comming Soon"
+shortDescription = "A place is not just its coordinates. It is the waft of petrichor, the sonic shifts of a street, the wear and tear of walls that have witnessed decades. Atlas of Intangibles is a data experience built from score-based walks, making the sensory legible through images, audio, and interconnected views."
+longDescription = """
+We know a place through our senses before we know it through any map. The waft of petrichor after rain. Bird songs in the background. The sound of traffic, the rhythm of footfalls, the marks left on walls by time and human activity. These fleeting encounters are the actual fabric of a place, and traditional cartography has no vocabulary for any of them.
+
+Atlas of Intangibles is Priti's attempt to build that vocabulary.
+
+The project begins on foot. Using score-based data walks, Priti collects sensory data through two lenses: Witness Marks, observations of wear, weathering, and the signs cities accumulate over time, and Sonic Shifts, the dynamic, layered soundscape of urban life. Each data point is rich in context, pairing field notes and sketches with photography, audio recordings, and video.
+The digital experience built from this data invites viewers to choose themes and explore the collected observations as three distinct views: journeys through the walk, connections between related data points, and typologies across the gathered material. The work asks what it looks like to preserve ambiguity and affect in a data experience rather than resolve them into a clean layer on a map.
+
+To extend the experience into the physical, Priti built a tangible interface: a set of cards, each embodying a specific recollection, that navigate the viewer to its associated data and connections when tapped on a reader. A keepsake box, not a database.
+
+This talk walks through the full process behind the work, examining alternate forms of data collection, the iterative design decisions, and the thinking behind data experiences that encourage a deeper connection with the places we inhabit.
+"""
 speakerName = "Priti Pandurangan"
 designation = "Information Experience Designer"
 organisation = ""
@@ -490,7 +511,7 @@ organisation = "Revisual Labs"
 speakerAbout = "Schubert is a frontend and dataviz developer at Revisual Labs. He spends much of his time building charts, scrollytelling pieces and interactives on the web. His work was among the winners of last year's Pudding Cup. He enjoys experimenting with design, motion and interaction to bring data and stories to life. Outside of work, you can find him on the losing side of a daily sketching habit."
 speakerImage = "/images/speakers/2026/speaker-schubert.avif"
 display = true
-order = 7
+order = 3
 
 [[session]]
 slug = "a-dataviz-crash-course"
@@ -509,7 +530,7 @@ organisation = "Independent"
 speakerAbout = "Prakriti is an independent data storyteller. She uses words, numbers, and visuals to clearly communicate complexity. \n\nMost recently, she worked as a data journalist at The Secretariat, where she wrote stories that analysed the impact of policies on people, profit, and planet. She has also worked as a data storyteller with Revisual Labs, an information design agency, translating dense information and messy ideas into sharp narratives. \n\nPrakriti earned an MSc in Computational and Data Journalism from Cardiff University and trained in slow, thoughtful journalism with Tortoise Media (now The Observer). She believes data storytelling is a necessary skill in an era of 47-second attention spans and has honed her craft by obsessing over the many small decisions that make a good data story."
 speakerImage = "/images/speakers/2026/speaker-prakriti.avif"
 display = true
-order = 6
+order = 3
 
 [[session]]
 slug = "data-rough"
@@ -529,7 +550,7 @@ organisation = "Reuters"
 speakerAbout = "Adolfo is a Spaniard based in Hong Kong that helps to create visual explanations across a spectrum of topics, supporting the drive at Reuters to present new ways to present news. He likes to use handcrafted illustrations to approach the subject and create appealing visual stories. Adolfo Arranz previously worked as a creative director at South China Morning Post in Hong Kong and Mediacorp in Singapore. He has won multiple prestigious awards in visual communication."
 speakerImage = "/images/speakers/2026/speaker-adolfo.avif"
 display = true
-order = 1
+order = 6
 
 [[session]]
 slug = "observe-collect-map"
@@ -548,7 +569,7 @@ organisation = ""
 speakerAbout = "Priti is a creative practitioner working globally across digital humanities, data, and computational futures through research, facilitation, and critical inquiry. Her personal practice explores pluralistic approaches to data and technology, focusing on forms of knowledge and epistemologies that resist quantification while holding space for lived experience, ambiguity, and affect.\n\nShe is also a data walker who facilitates data walks in cities around the world, enabling participants to engage with urban environments through situated and embodied interpretations.\n\nCentral to her work is how culture is held, transmitted, and reconfigured across contexts and temporalities, and the structures through which it is preserved and interpreted."
 speakerImage = "/images/speakers/2026/speaker-priti.avif"
 display = true
-order = 2
+order = 1
 
 [[session]]
 slug = "interactive-dataviz-using-ai-coding"
@@ -568,7 +589,7 @@ speakerAbout = "Kenneth Dsouza is an experienced product designer with a Master'
 speakerImage = "/images/speakers/2026/speaker-kenneth.avif"
 display = true
 soldOut = true
-order = 3
+order = 6
 
 [[session]]
 slug = "designing-data-stories-for-small-screens"
@@ -587,4 +608,4 @@ organisation = "The Hindu"
 speakerAbout = "Areena Arora is a journalist who transforms messy data into stories that matter. She uncovers patterns hidden in datasets, then designs how people encounter and understand those stories.\n\nHer work sits at the intersection of rigorous reporting and intentional design. She asks: What is the data trying to tell us? How do we present it such that people actually listen and grasp its intricacies? Before finding her way to this unique blend as The Hindu's first-ever Editorial Coder, she reported on public education and local governance in Tennessee, U.S.\n\nShe's obsessed with making complexity accessible. When she's not chasing stories in data, she's cooking up a storm, always up for feeding an army."
 speakerImage = "/images/speakers/2026/speaker-areena.avif"
 display = true
-order = 4
+order = 2

--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -201,18 +201,20 @@
 	</div>
 {:else}
 	{@const currentColor = colorClasses[color] ?? colorClasses.blue}
-	<div class="sessions-card-wrapper group @container relative mx-auto w-full">
+	<div
+		class="sessions-card-wrapper group @container relative mx-auto w-full overflow-hidden rounded"
+	>
+		{#if soldOut}
+			<div class="sold-out-ribbon" style="background: {shadowColor};">
+				<span class="sold-out-ribbon-text">Sold Out</span>
+			</div>
+		{/if}
 		<a
 			href={detailHref}
 			class="sessions-card bg-viz-white border-viz-grey/40 isolate block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] group-hover:scale-102"
 			onpointermove={handlePointerMove}
 			onpointerleave={handlePointerLeave}
 		>
-			{#if soldOut}
-				<div class="sold-out-ribbon">
-					<span class="sold-out-ribbon-text">Sold Out</span>
-				</div>
-			{/if}
 			<div
 				class="session-card-body relative flex aspect-4/5.75 max-h-[85svh] flex-col md:max-h-none {soldOut
 					? 'sold-out-card'
@@ -480,11 +482,10 @@
 	.sold-out-ribbon {
 		position: absolute;
 		top: 38px;
-		left: -55px;
+		right: -70px;
 		z-index: 30;
-		width: 240px;
-		background: var(--color-viz-orange, oklch(76% 0.161 82));
-		transform: rotate(-35deg);
+		width: 320px;
+		transform: rotate(35deg);
 		text-align: center;
 		padding: 10px 0;
 		pointer-events: none;


### PR DESCRIPTION
## Summary
- Move sold-out ribbon to top-right corner, outside the `overflow-hidden` anchor so it renders as a proper diagonal ribbon strip
- Color now matches the card's session tone instead of hardcoded orange
- Update Jaidev Deshpande's talk to "Caption This: Teaching Machines to Narrate Charts" with new title, subtitle, and description
- Expand Atlas of Intangibles description (Priti Pandurangan)

## Test plan
- [x] Verify sold-out ribbon appears as a diagonal strip in the top-right corner on session cards
- [x] Verify ribbon color matches the session card color (blue for Talks, etc.)
- [x] Verify Jaidev's talk shows updated title and description on the sessions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)