### PR TITLE
Fix session ticket buttons and View Details card linking

### DIFF
--- a/content/2026/data/sessions.toml
+++ b/content/2026/data/sessions.toml
@@ -26,6 +26,7 @@ He has written about data, analytics, and AI on his Substack The Art of Data Sci
 speakerImage = "/images/speakers/2026/speaker-karthik.webp"
 display = true
 pageReady = true
+ticketCode = "agentic_dataviz"
 order = 1
 
 
@@ -407,7 +408,7 @@ longDescription = "Bar charts with truncated axes. Correlations that vanish when
 speakerName = "Agriya Khetarpal"
 designation = "Software Engineer"
 organisation = "Quansight"
-speakerAbout = "Agriya is a software engineer at Quansight, where he works on scientific open source software in the Scientific Python and Jupyter ecosystems. He is passionate about advancing science policy in India and believes that data, communicated honestly and rigorously, is one of its most powerful tools ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ a conviction that keeps him equally at home, whether in a terminal or in a policy debate."
+speakerAbout = "Agriya is a software engineer at Quansight, where he works on scientific open source software in the Scientific Python and Jupyter ecosystems. He is passionate about advancing science policy in India and believes that data, communicated honestly and rigorously, is one of its most powerful tools, a conviction that keeps him equally at home, whether in a terminal or in a policy debate."
 speakerImage = "/images/speakers/2026/speaker-agriya.avif"
 display = true
 pageReady = true
@@ -673,6 +674,7 @@ speakerAbout = "Prasanta Kumar Dutta is an award-winning Information Experience 
 speakerImage = "/images/speakers/2026/speaker-prasanta.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_maps"
 order = 5
 
 
@@ -680,7 +682,7 @@ order = 5
 slug = "draw-with-data"
 sessionType = "Workshops"
 date = "2026-07-03"
-time = "10:00 ÃÂÃÂ¢ÃÂÃÂÃÂÃÂ 13:00"
+time = "10:00 - 13:00"
 slot = "morning"
 venue = "Underline Center"
 title = "Draw with Data: Custom Dataviz Using D3"
@@ -694,6 +696,7 @@ speakerAbout = "Schubert is a frontend and dataviz developer at Revisual Labs. H
 speakerImage = "/images/speakers/2026/speaker-schubert.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_d3_viz"
 order = 3
 
 
@@ -715,6 +718,7 @@ speakerAbout = "Prakriti is an independent data storyteller. She uses words, num
 speakerImage = "/images/speakers/2026/speaker-prakriti.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_datavix_course"
 order = 3
 
 
@@ -737,6 +741,7 @@ speakerAbout = "Adolfo is a Spaniard based in Hong Kong that helps to create vis
 speakerImage = "/images/speakers/2026/speaker-adolfo.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_data_rough"
 order = 6
 
 
@@ -758,6 +763,7 @@ speakerAbout = "Priti is a creative practitioner working globally across digital
 speakerImage = "/images/speakers/2026/speaker-priti.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_datawalk"
 order = 1
 
 
@@ -779,6 +785,7 @@ speakerAbout = "Kenneth Dsouza is an experienced product designer with a Master'
 speakerImage = "/images/speakers/2026/speaker-kenneth.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_ai_data_vix"
 soldOut = true
 order = 6
 
@@ -801,4 +808,5 @@ speakerAbout = "Areena Arora is a journalist who transforms messy data into stor
 speakerImage = "/images/speakers/2026/speaker-areena.avif"
 display = true
 pageReady = true
+ticketCode = "workshop_2026_mobile_viz"
 order = 2

--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -201,223 +201,225 @@
 	</div>
 {:else}
 	{@const currentColor = colorClasses[color] ?? colorClasses.blue}
-	<div
-		class="sessions-card-wrapper group @container relative mx-auto w-full overflow-hidden rounded"
-	>
-		{#if soldOut}
-			<div class="sold-out-ribbon" style="background: {shadowColor};">
-				<span class="sold-out-ribbon-text">Sold Out</span>
-			</div>
-		{/if}
-		<svelte:element
-			this={pageReady ? 'a' : 'div'}
-			href={pageReady ? detailHref : undefined}
-			class="sessions-card bg-viz-white border-viz-grey/40 isolate block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] {pageReady
-				? 'cursor-pointer group-hover:scale-102'
-				: 'cursor-default'}"
-			onpointermove={handlePointerMove}
-			onpointerleave={handlePointerLeave}
-		>
+	<div class="sessions-card-outer group relative mx-auto w-full">
+		<div class="sessions-card-wrapper @container relative w-full overflow-hidden rounded">
 			{#if soldOut}
-				<div class="sold-out-ribbon">
+				<div class="sold-out-ribbon" style="background: {shadowColor};">
 					<span class="sold-out-ribbon-text">Sold Out</span>
 				</div>
 			{/if}
-			<div
-				class="session-card-body relative flex aspect-4/5.75 max-h-[85svh] flex-col md:max-h-none {soldOut
-					? 'sold-out-card'
-					: ''}"
-				bind:clientWidth={backgroundWidth}
-				bind:clientHeight={backgroundHeight}
+			<svelte:element
+				this={pageReady ? 'a' : 'div'}
+				href={pageReady ? detailHref : undefined}
+				class="sessions-card bg-viz-white border-viz-grey/40 isolate block w-full transform-gpu overflow-hidden rounded border transition-[transform,box-shadow] {pageReady
+					? 'cursor-pointer group-hover:scale-102'
+					: 'cursor-default'}"
+				onpointermove={handlePointerMove}
+				onpointerleave={handlePointerLeave}
 			>
-				<!-- Pattern anchored to full card so translate % is stable regardless of flex split -->
-				<div class="pattern-bg-expanded absolute inset-0 z-0 overflow-visible">
-					{#if expandedBgWidth > 0}
-						<SessionCardBackground
-							{sessionType}
-							{color}
-							{variation}
-							{seed}
-							width={expandedBgWidth}
-							height={expandedBgWidth}
-							class="h-full w-full"
-						/>
-					{/if}
-				</div>
-				<div class="session-top-text-content z-20">
-					<div class="session-card-header relative z-10 p-2.5 pb-0! md:p-4">
-						<div class="title mb-2.5 flex flex-row items-baseline justify-start gap-2 md:mb-3">
-							<div class="logo-container text-xl leading-none text-[#4c4c4c] md:text-2xl">
-								<LogoType classes="text-xl md:text-2xl" year={null} />
-							</div>
-
-							<!-- <div class="divider my-0.5 w-0.5 self-stretch bg-[#4c4c4c]"></div> -->
-							<p
-								class="font-display text-shadow block text-xl leading-none tracking-tighter uppercase md:text-2xl"
-								style="color: {themeTokens[color]?.dark ??
-									themeTokens.blue.dark}; font-variation-settings: 'wght' 600;"
-							>
-								{sessionType}
-							</p>
-						</div>
-
-						<div class="sessions-logistics hidden">
-							<div class="text-base leading-none uppercase md:text-base">
-								{#if time}
-									<span class="font-display leading-snug! font-bold md:text-[17px]">{time} ⋅ </span>
-									{#if slot}<span class="font-display leading-snug! font-bold md:text-[17px]"
-											>{slot}</span
-										>{/if}
-								{/if}
-								{#if venue}
-									<p class="text-base leading-none uppercase md:text-base">
-										<span class="font-display leading-none! font-light md:text-[16px]"
-											>{venue}
-										</span>
-									</p>
-								{/if}
-							</div>
-						</div>
+				{#if soldOut}
+					<div class="sold-out-ribbon">
+						<span class="sold-out-ribbon-text">Sold Out</span>
 					</div>
+				{/if}
+				<div
+					class="session-card-body relative flex aspect-4/5.75 max-h-[85svh] flex-col md:max-h-none {soldOut
+						? 'sold-out-card'
+						: ''}"
+					bind:clientWidth={backgroundWidth}
+					bind:clientHeight={backgroundHeight}
+				>
+					<!-- Pattern anchored to full card so translate % is stable regardless of flex split -->
+					<div class="pattern-bg-expanded absolute inset-0 z-0 overflow-visible">
+						{#if expandedBgWidth > 0}
+							<SessionCardBackground
+								{sessionType}
+								{color}
+								{variation}
+								{seed}
+								width={expandedBgWidth}
+								height={expandedBgWidth}
+								class="h-full w-full"
+							/>
+						{/if}
+					</div>
+					<div class="session-top-text-content z-20">
+						<div class="session-card-header relative z-10 p-2.5 pb-0! md:p-4">
+							<div class="title mb-2.5 flex flex-row items-baseline justify-start gap-2 md:mb-3">
+								<div class="logo-container text-xl leading-none text-[#4c4c4c] md:text-2xl">
+									<LogoType classes="text-xl md:text-2xl" year={null} />
+								</div>
 
-					<div
-						class="title-content relative z-10 p-3 pt-1 md:p-4 md:pt-3"
-						style={layout.titlePaddingRatio && backgroundWidth > 0
-							? `padding-top: ${Math.round(backgroundWidth * layout.titlePaddingRatio)}px`
-							: undefined}
-					>
-						<h3
-							class="title font-display text-shadow mb-1 text-[20px] leading-none font-extrabold text-[#4c4c4c] uppercase md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
-							style={layout.titleMaxWidth ? `max-width: ${layout.titleMaxWidth}` : undefined}
+								<!-- <div class="divider my-0.5 w-0.5 self-stretch bg-[#4c4c4c]"></div> -->
+								<p
+									class="font-display text-shadow block text-xl leading-none tracking-tighter uppercase md:text-2xl"
+									style="color: {themeTokens[color]?.dark ??
+										themeTokens.blue.dark}; font-variation-settings: 'wght' 600;"
+								>
+									{sessionType}
+								</p>
+							</div>
+
+							<div class="sessions-logistics hidden">
+								<div class="text-base leading-none uppercase md:text-base">
+									{#if time}
+										<span class="font-display leading-snug! font-bold md:text-[17px]"
+											>{time} ⋅
+										</span>
+										{#if slot}<span class="font-display leading-snug! font-bold md:text-[17px]"
+												>{slot}</span
+											>{/if}
+									{/if}
+									{#if venue}
+										<p class="text-base leading-none uppercase md:text-base">
+											<span class="font-display leading-none! font-light md:text-[16px]"
+												>{venue}
+											</span>
+										</p>
+									{/if}
+								</div>
+							</div>
+						</div>
+
+						<div
+							class="title-content relative z-10 p-3 pt-1 md:p-4 md:pt-3"
+							style={layout.titlePaddingRatio && backgroundWidth > 0
+								? `padding-top: ${Math.round(backgroundWidth * layout.titlePaddingRatio)}px`
+								: undefined}
 						>
-							{title}
-						</h3>
-						<!-- {#if subtitle}
+							<h3
+								class="title font-display text-shadow mb-1 text-[20px] leading-none font-extrabold text-[#4c4c4c] uppercase md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
+								style={layout.titleMaxWidth ? `max-width: ${layout.titleMaxWidth}` : undefined}
+							>
+								{title}
+							</h3>
+							<!-- {#if subtitle}
 					<p
 						class="subtitle font-display text-shadow mb-1 text-[20px] leading-none font-extrabold text-[#4c4c4c] uppercase md:text-[28px]"
 					></p>
 				{/if} -->
+						</div>
+
+						{#if isExpanded}
+							<div class="short-description-container relative z-10 p-3 pt-0 md:p-4 md:pt-1">
+								<!-- float pushes text away from the photo/pattern on the right -->
+								<div
+									class="text-shape-float"
+									style="width: {layout.floatWidth}; height: {layout.floatHeight};"
+									aria-hidden="true"
+								></div>
+								<!-- div (not p) so that inner <p> tags from descriptionHtml don't break float context -->
+								<div
+									class="short-description font-body text-shadow mb-1 text-[15px] leading-tight font-normal text-[#4c4c4c] md:text-[18px]"
+								>
+									{subtitle}
+								</div>
+							</div>
+						{/if}
+					</div>
+					<div
+						class="background-container-expanded relative z-0 flex w-full flex-1 flex-row items-center justify-end"
+					>
+						{#each (speakerImage || '')
+							.split('//')
+							.map((s) => s.trim())
+							.filter(Boolean) as img, i}
+							<div
+								class="speaker-image pointer-events-none absolute bottom-0 origin-center transition-transform duration-300 group-hover:scale-104 group-hover:rotate-1"
+								style:right="{5 + i * 30}%"
+								style:transform={buildSpeakerImageTransform(speakerName, screenWidth, sessionType)}
+							>
+								<img
+									class="relative z-10 h-auto w-full"
+									style="filter: drop-shadow(0px 8px 16px {shadowColor}cc)"
+									src={img}
+									alt={speakerName?.split('//')[i]?.trim() ?? speakerName ?? ''}
+								/>
+							</div>
+						{:else}
+							<div
+								class="speaker-image pointer-events-none absolute right-5 bottom-0 origin-center transition-transform duration-300 group-hover:scale-104 group-hover:rotate-1"
+								style:transform={buildSpeakerImageTransform(speakerName, screenWidth, sessionType)}
+							>
+								<img
+									class="relative z-10 h-auto w-full"
+									style="filter: drop-shadow(0px 8px 16px {shadowColor}cc)"
+									src="/images/speakers/2026/speaker-placeholder.avif"
+									alt={speakerName ?? ''}
+								/>
+							</div>
+						{/each}
 					</div>
 
-					{#if isExpanded}
-						<div class="short-description-container relative z-10 p-3 pt-0 md:p-4 md:pt-1">
-							<!-- float pushes text away from the photo/pattern on the right -->
-							<div
-								class="text-shape-float"
-								style="width: {layout.floatWidth}; height: {layout.floatHeight};"
-								aria-hidden="true"
-							></div>
-							<!-- div (not p) so that inner <p> tags from descriptionHtml don't break float context -->
-							<div
-								class="short-description font-body text-shadow mb-1 text-[15px] leading-tight font-normal text-[#4c4c4c] md:text-[18px]"
-							>
-								{subtitle}
+					<div
+						class="speaker-details-overlay pointer-events-auto absolute inset-x-0 bottom-0 z-10 flex flex-col"
+					>
+						<!-- wave height = card-width/3; padding-bottom% is relative to own width (inset-x-0) -->
+						<div
+							class="absolute inset-x-0 -bottom-px"
+							style="height: 0; padding-bottom: calc(33.34% + 2px);"
+						>
+							<div class="absolute inset-0">
+								<svg
+									class="relative z-0 block h-full w-full"
+									viewBox="0 0 1080 364"
+									preserveAspectRatio="none"
+									fill="none"
+									aria-hidden="true"
+								>
+									<path
+										d="M-12 364.516V0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636V364.516H-12Z"
+										fill={overlayColor}
+									/>
+									<path
+										d="M-12 0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636"
+										fill="none"
+										stroke="#fff"
+										stroke-width={overlayStrokeWidth}
+									/>
+								</svg>
 							</div>
 						</div>
-					{/if}
-				</div>
-				<div
-					class="background-container-expanded relative z-0 flex w-full flex-1 flex-row items-center justify-end"
-				>
-					{#each (speakerImage || '')
-						.split('//')
-						.map((s) => s.trim())
-						.filter(Boolean) as img, i}
-						<div
-							class="speaker-image pointer-events-none absolute bottom-0 origin-center transition-transform duration-300 group-hover:scale-104 group-hover:rotate-1"
-							style:right="{5 + i * 30}%"
-							style:transform={buildSpeakerImageTransform(speakerName, screenWidth, sessionType)}
-						>
-							<img
-								class="relative z-10 h-auto w-full"
-								style="filter: drop-shadow(0px 8px 16px {shadowColor}cc)"
-								src={img}
-								alt={speakerName?.split('//')[i]?.trim() ?? speakerName ?? ''}
-							/>
-						</div>
-					{:else}
-						<div
-							class="speaker-image pointer-events-none absolute right-5 bottom-0 origin-center transition-transform duration-300 group-hover:scale-104 group-hover:rotate-1"
-							style:transform={buildSpeakerImageTransform(speakerName, screenWidth, sessionType)}
-						>
-							<img
-								class="relative z-10 h-auto w-full"
-								style="filter: drop-shadow(0px 8px 16px {shadowColor}cc)"
-								src="/images/speakers/2026/speaker-placeholder.avif"
-								alt={speakerName ?? ''}
-							/>
-						</div>
-					{/each}
-				</div>
 
-				<div
-					class="speaker-details-overlay pointer-events-auto absolute inset-x-0 bottom-0 z-10 flex flex-col"
-				>
-					<!-- wave height = card-width/3; padding-bottom% is relative to own width (inset-x-0) -->
-					<div
-						class="absolute inset-x-0 -bottom-px"
-						style="height: 0; padding-bottom: calc(33.34% + 2px);"
-					>
-						<div class="absolute inset-0">
-							<svg
-								class="relative z-0 block h-full w-full"
-								viewBox="0 0 1080 364"
-								preserveAspectRatio="none"
-								fill="none"
-								aria-hidden="true"
-							>
-								<path
-									d="M-12 364.516V0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636V364.516H-12Z"
-									fill={overlayColor}
-								/>
-								<path
-									d="M-12 0.516363C191.5 -0.982956 456 101.337 579 114.518C705 128.018 1004.5 9.01752 1092 2.01636"
-									fill="none"
-									stroke="#fff"
-									stroke-width={overlayStrokeWidth}
-								/>
-							</svg>
-						</div>
-					</div>
-
-					<div class="speaker-details-content relative z-30 mt-auto w-full p-2.5 md:p-4">
-						<div class="speaker-details relative z-10">
-							<h3
-								class="font-display text-shadow mb-1 text-[18px] leading-none text-[#4c4c4c] uppercase md:text-[20px] lg:text-[22px] 2xl:text-[26px] 2xl:text-shadow-none!"
-							>
-								{#each speakerName.split('//').map((s) => s.trim()) as person, i}
-									{@const isDual = speakerName.includes('//')}
-									{#if i > 0}<span
-											class="text-[18px] leading-none font-medium md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
-										>
-											&nbsp;//
-										</span>{/if}
-									<span
-										class="first-name text-[18px] leading-none font-extrabold md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
-										>{person.split(' ')[0]}</span
-									>
-									<span
-										class="last-name text-[18px] leading-none font-medium md:text-[20px] lg:text-[22px] 2xl:text-[28px] {isDual
-											? 'hidden @sm:inline'
-											: ''}">{person.split(' ').slice(1).join(' ')}</span
-									>
-								{/each}
-							</h3>
-							{#if designation || organisation}
-								<span
-									class="font-display block text-sm leading-tight text-[#4c4c4c] md:text-[14px] lg:text-[15px] 2xl:text-lg"
+						<div class="speaker-details-content relative z-30 mt-auto w-full p-2.5 md:p-4">
+							<div class="speaker-details relative z-10">
+								<h3
+									class="font-display text-shadow mb-1 text-[18px] leading-none text-[#4c4c4c] uppercase md:text-[20px] lg:text-[22px] 2xl:text-[26px] 2xl:text-shadow-none!"
 								>
-									{#if designation}
-										{designation}
-									{/if}{#if organisation}, {organisation}
-									{/if}
-								</span>
-							{/if}
+									{#each speakerName.split('//').map((s) => s.trim()) as person, i}
+										{@const isDual = speakerName.includes('//')}
+										{#if i > 0}<span
+												class="text-[18px] leading-none font-medium md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
+											>
+												&nbsp;//
+											</span>{/if}
+										<span
+											class="first-name text-[18px] leading-none font-extrabold md:text-[20px] lg:text-[22px] 2xl:text-[28px]"
+											>{person.split(' ')[0]}</span
+										>
+										<span
+											class="last-name text-[18px] leading-none font-medium md:text-[20px] lg:text-[22px] 2xl:text-[28px] {isDual
+												? 'hidden @sm:inline'
+												: ''}">{person.split(' ').slice(1).join(' ')}</span
+										>
+									{/each}
+								</h3>
+								{#if designation || organisation}
+									<span
+										class="font-display block text-sm leading-tight text-[#4c4c4c] md:text-[14px] lg:text-[15px] 2xl:text-lg"
+									>
+										{#if designation}
+											{designation}
+										{/if}{#if organisation}, {organisation}
+										{/if}
+									</span>
+								{/if}
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
-		</svelte:element>
+			</svelte:element>
+		</div>
 
 		{#if pageReady}
 			<svg
@@ -519,13 +521,13 @@
 		text-transform: uppercase;
 	}
 
-	.sessions-card-wrapper {
+	.sessions-card-outer {
 		box-shadow:
 			rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
 			rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
 	}
 
-	.sessions-card-wrapper:hover {
+	.sessions-card-outer:hover {
 		box-shadow:
 			rgba(50, 50, 93, 0.2) 0px 10px 15px -2px,
 			rgba(0, 0, 0, 0.2) 0px 6px 8px -3px;

--- a/src/lib/utils/sessions.ts
+++ b/src/lib/utils/sessions.ts
@@ -30,6 +30,7 @@ export interface SessionData {
 	soldOut?: boolean;
 	order?: number;
 	pageReady?: boolean;
+	ticketCode?: string;
 }
 
 export function getSessionOrder(s: Pick<SessionData, 'order'>): number {

--- a/src/routes/2026/sessions/[slug]/+page.svelte
+++ b/src/routes/2026/sessions/[slug]/+page.svelte
@@ -16,6 +16,19 @@
 	const session = $derived(data.session);
 	const color = $derived(sessionColorMap[session.sessionType] ?? 'blue');
 
+	const ticketBtnClass: Record<string, string> = {
+		blue: 'bg-viz-blue-dark hover:bg-viz-blue',
+		teal: 'bg-viz-teal-dark hover:bg-viz-teal',
+		pink: 'bg-viz-pink-dark hover:bg-viz-pink',
+		orange: 'bg-viz-orange-dark hover:bg-viz-orange'
+	};
+	const soldOutBtnClass: Record<string, string> = {
+		blue: 'bg-viz-blue',
+		teal: 'bg-viz-teal',
+		pink: 'bg-viz-pink',
+		orange: 'bg-viz-orange'
+	};
+
 	const backLink = $derived.by(() => {
 		if (!browser) return { href: '/2026/sessions', label: 'Back to All Sessions' };
 		const from = page.url.searchParams.get('from');
@@ -189,14 +202,53 @@
 		</div>
 
 		<!-- Tickets -->
-		<div class="mt-8">
+		<div class="mt-8 flex flex-wrap gap-3">
+			{#if session.sessionType === 'Workshops' && session.ticketCode}
+				{#if session.soldOut}
+					<span
+						class="font-display inline-flex cursor-not-allowed items-center rounded-full px-5 py-2 text-sm font-extrabold tracking-[0.15em] text-white uppercase {soldOutBtnClass[
+							color
+						]}"
+						style="box-shadow: 0 3px 10px rgba(0,0,0,0.2)"
+					>
+						Workshop Sold Out
+					</span>
+				{:else}
+					<a
+						href="https://tickets.vizchitra.com/?ticket={session.ticketCode}"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="font-display inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-bold text-white uppercase transition-colors {ticketBtnClass[
+							color
+						]}"
+					>
+						Get Workshop Ticket
+						<svg
+							class="h-4 w-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M14 5l7 7m0 0l-7 7m7-7H3"
+							/>
+						</svg>
+					</a>
+				{/if}
+			{/if}
 			<a
-				href="https://tickets.vizchitra.com/"
+				href="https://tickets.vizchitra.com/?ticket=conference_practitioner"
 				target="_blank"
 				rel="noopener noreferrer"
-				class="font-display bg-viz-{color}-dark hover:bg-viz-{color} inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-bold text-white uppercase transition-colors"
+				class="font-display inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-bold text-white uppercase transition-colors {ticketBtnClass[
+					color
+				]}"
 			>
-				Purchase Tickets
+				Get Conference Ticket
 				<svg
 					class="h-4 w-4"
 					fill="none"


### PR DESCRIPTION
## Summary
- **Ticket buttons on session detail pages**: Show "Get Workshop Ticket" (workshops with `ticketCode`) and "Get Conference Ticket" (all sessions) using static color lookup maps — fixes invisible buttons caused by Tailwind not scanning dynamic class template literals
- **Workshop sold-out state**: Non-clickable pill badge in session color with ribbon-style typography, no arrow
- **`ticketCode` field**: Added to `SessionData` interface and all 8 workshop sessions in TOML (fill in actual codes)
- **View Details circular button**: Fixed `overflow-hidden` on card wrapper clipping the button — moved SVG outside the wrapper into a new outer `group` container

## Test plan
- [ ] Talks/Dialogues/Exhibition session pages show "Get Conference Ticket" in their session color
- [ ] Workshop pages show both "Get Workshop Ticket" and "Get Conference Ticket"
- [ ] Sold-out workshops show "Workshop Sold Out" badge (no link, no arrow)
- [ ] View Details circular button appears on hover for `pageReady` cards on `/2026` and `/2026/sessions`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)