### PR TITLE
feat: update funding channels with mailto links and improve text clarity

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+# License
+
+## Code
+
+The source code in this repository is licensed under the MIT License.
+
+MIT License — applies to code only.
+
+Copyright © 2026 VizChitra Collective Private Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Content
+
+Website content, branding, visual design, written materials, and all other non-code assets are copyright © 2026 VizChitra Collective Private Limited. All rights reserved.

--- a/src/routes/funding/+page.svelte
+++ b/src/routes/funding/+page.svelte
@@ -150,9 +150,7 @@
 									Contribute
 								</Button>
 							{:else if channel.type === 'bank'}
-								<Button href={channel.address} color={buttonColor} size="sm">
-									Contact for Details
-								</Button>
+								<Button href={channel.address} color={buttonColor} size="sm">Email Us</Button>
 							{/if}
 						</div>
 					{/if}
@@ -174,7 +172,7 @@
 								payment link
 							</a>)
 						{:else}
-							(<a href={channel.address}> contact us </a>)
+							(<a href={channel.address}> email us </a>)
 						{/if}
 					</li>
 				{/each}

--- a/src/routes/funding/+page.svelte
+++ b/src/routes/funding/+page.svelte
@@ -177,15 +177,6 @@
 					</li>
 				{/each}
 			</ul>
-			<p>
-				View the <a
-					href="https://vizchitra.com/funding.json"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					machine readable version
-				</a>
-			</p>
 		</Prose>
 	</Stack>
 </Container>

--- a/src/routes/funding/+page.svelte
+++ b/src/routes/funding/+page.svelte
@@ -150,7 +150,7 @@
 									Contribute
 								</Button>
 							{:else if channel.type === 'bank'}
-								<Button href="mailto:{data.fundingData.entity.email}" color={buttonColor} size="sm">
+								<Button href={channel.address} color={buttonColor} size="sm">
 									Contact for Details
 								</Button>
 							{/if}
@@ -174,9 +174,7 @@
 								payment link
 							</a>)
 						{:else}
-							(<a href="mailto:{data.fundingData.entity.email}">
-								{data.fundingData.entity.email}
-							</a>)
+							(<a href={channel.address}> contact us </a>)
 						{/if}
 					</li>
 				{/each}

--- a/static/funding.json
+++ b/static/funding.json
@@ -6,11 +6,26 @@
 		"role": "steward",
 		"name": "VizChitra Collective Private Limited",
 		"email": "hello@vizchitra.com",
-		"description": "VizChitra is India's data visualisation community and annual conference, based in Bengaluru. We bring together designers, developers, journalists, researchers, and analysts working at the intersection of data and visual communication. \n We are fully volunteer-driven, run an open call for sessions with feedback to every proposal, and publish guides and resources to support speakers, facilitators, and the wider community. \n VizChitra 2026 takes place 3-4 July at the Bangalore International Centre.",
+		"description": "VizChitra is India's data visualisation community and annual conference, based in Bengaluru. We bring together designers, developers, journalists, researchers, and analysts working at the intersection of data and visual communication. \n\n We are fully volunteer-driven, run an open call for sessions with feedback to every proposal, and publish guides and resources to support speakers, facilitators, and the wider community.",
 		"webpageUrl": {
 			"url": "https://vizchitra.com"
 		}
 	},
+	"projects": [
+		{
+			"guid": "vizchitra-conference",
+			"name": "VizChitra Conference",
+			"description": "VizChitra is India's annual data visualisation conference and community, bringing together designers, developers, journalists, researchers, and analysts working at the intersection of data and visual communication.\n\n VizChitra 2026 takes place 3-4 July at the Bangalore International Centre.",
+			"webpageUrl": {
+				"url": "https://vizchitra.com"
+			},
+			"repositoryUrl": {
+				"url": "https://github.com/vizchitra/website"
+			},
+			"licenses": ["spdx:MIT"],
+			"tags": ["data-visualization", "education", "design", "data"]
+		}
+	],
 	"funding": {
 		"channels": [
 			{
@@ -22,8 +37,8 @@
 			{
 				"guid": "bank-transfer",
 				"type": "bank",
-				"address": "Write to hello@vizchitra.com for bank details",
-				"description": "Direct bank transfer, for sponsorships and larger contributions. GST-compliant invoice provided."
+				"address": "mailto:hello@vizchitra.com?subject=VizChitra%202026%20Sponsorship%20%2F%20Contribution",
+				"description": "Direct bank transfer for sponsorships and larger contributions. Email us to receive bank details. GST-compliant invoice provided."
 			}
 		],
 		"plans": [
@@ -41,7 +56,7 @@
 				"guid": "community-support",
 				"status": "active",
 				"name": "Community Support",
-				"description": "Support travel and accommodation for speakers, facilitators, and artists coming from outside Bengaluru, India, and South Asia. We fund ₹15,000 per outstation contributor. ₹50,000 supports travel for 3-4 contributors, broadening the voices represented at VizChitra.",
+				"description": "Support travel and accommodation for speakers, facilitators, and artists coming from outside Bengaluru, India, and South Asia. We fund ₹15,000 per outstation contributor. ₹50,000 supports travel for 3-4 contributors, broadening the voices represented at VizChitra 2026.",
 				"amount": 50000,
 				"currency": "INR",
 				"frequency": "one-time",


### PR DESCRIPTION
## Summary
- Update bank transfer channel to use mailto link
- Change button text to 'Email Us' for clarity
- Remove duplicate manifest link from funding channels
- Add LICENSE.md

## Changes
- Bank transfer address now uses mailto link with subject for sponsorship inquiries
- Plan buttons and funding channels consistently use 'Email Us' for bank transfers
- Consolidated manifest reference to entity metadata section
- Added project information and proper newline rendering

## Test plan
- [ ] Verify bank transfer button and link work correctly
- [ ] Check "Email Us" text renders in both plan cards and channels list
- [ ] Confirm manifest link still accessible in entity metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)