### PR TITLE
Keep sold-out ribbon inside its card in the overlapping fan

### DIFF
--- a/src/lib/components/sessions/SessionCardExpanded.svelte
+++ b/src/lib/components/sessions/SessionCardExpanded.svelte
@@ -522,6 +522,9 @@
 	}
 
 	.sessions-card-outer {
+		/* Scope the sold-out ribbon's z-index to this card so it can't paint over
+		   neighbouring cards in the overlapping fan layout on the home page. */
+		isolation: isolate;
 		box-shadow:
 			rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
 			rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;


### PR DESCRIPTION
Isolate each card's stacking context so the ribbon's z-index no longer paints over neighbouring cards in the home page fan layout.