### PR TITLE
Fix: Use html-to-image to fix broken selfie downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"@handlewithcare/remark-prosemirror": "^0.1.5",
 		"fuse.js": "^7.3.0",
+		"html-to-image": "^1.11.13",
 		"prosemirror-tables": "^1.8.5",
 		"qrcode": "^1.5.4",
 		"remark-parse": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       fuse.js:
         specifier: ^7.3.0
         version: 7.3.0
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       prosemirror-tables:
         specifier: ^1.8.5
         version: 1.8.5
@@ -2229,6 +2232,9 @@ packages:
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -4846,6 +4852,8 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   hex-rgb@4.3.0: {}
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 

--- a/src/lib/utils/screenshot.ts
+++ b/src/lib/utils/screenshot.ts
@@ -1,95 +1,46 @@
-interface CaptureOptions {
+import * as htmlToImage from 'html-to-image';
+
+export interface CaptureOptions {
 	scale?: number;
 	backgroundColor?: string;
+	pixelRatio?: number;
 }
 
-interface CaptureResult {
+export interface CaptureResult {
 	dataUrl: string;
-	canvas: HTMLCanvasElement;
-	blob: Blob;
+	blob: Blob | null;
 	download: (filename?: string) => void;
 }
 
-// Capture DOM node as PNG using native browser APIs
+// Capture DOM node as PNG using html-to-image library
+
 export async function captureNodeAsPNG(
 	element: HTMLElement,
 	options: CaptureOptions = {}
 ): Promise<CaptureResult> {
 	try {
-		const { scale = 2, backgroundColor = '#ffffff' } = options;
+		const { scale = 2, backgroundColor = '#ffffff', pixelRatio } = options;
 
-		// Get element dimensions
-		const rect = element.getBoundingClientRect();
-		const width = rect.width * scale;
-		const height = rect.height * scale;
+		const imageOptions = {
+			backgroundColor,
+			pixelRatio: pixelRatio ?? scale
+		};
 
-		// Clone the element to avoid modifying original
-		const clone = element.cloneNode(true);
-
-		// Get computed styles
-		const styles = window.getComputedStyle(element);
-		const styleString = Array.from(styles).reduce((str, property) => {
-			return `${str}${property}:${styles.getPropertyValue(property)};`;
-		}, '');
-
-		// Create SVG with foreignObject
-		const svg = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
-        <foreignObject width="100%" height="100%">
-          <div xmlns="http://www.w3.org/2000/svg" style="${styleString}">
-            ${element.outerHTML}
-          </div>
-        </foreignObject>
-      </svg>
-    `;
-
-		// Convert SVG to blob
-		const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-
-		// Load image from SVG
-		const img = new Image();
-		img.width = width;
-		img.height = height;
-
-		await new Promise<void>((resolve, reject) => {
-			img.onload = () => resolve();
-			img.onerror = () => reject();
-			img.src = url;
-		});
-
-		// Draw to canvas
-		const canvas = document.createElement('canvas');
-		canvas.width = width;
-		canvas.height = height;
-		const ctx = canvas.getContext('2d');
-
-		if (!ctx) {
-			throw new Error('Could not get canvas context');
-		}
-
-		// Set background
-		ctx.fillStyle = backgroundColor;
-		ctx.fillRect(0, 0, width, height);
-
-		// Draw image
-		ctx.drawImage(img, 0, 0, width, height);
-
-		// Clean up
-		URL.revokeObjectURL(url);
-
-		// Convert to PNG
-		const pngDataUrl = canvas.toDataURL('image/png');
+		const [dataUrl, blob] = await Promise.all([
+			htmlToImage.toPng(element, imageOptions),
+			htmlToImage.toBlob(element, imageOptions)
+		]);
 
 		return {
-			dataUrl: pngDataUrl,
-			canvas: canvas,
-			blob: await new Promise((resolve) => canvas.toBlob(resolve, 'image/png')),
+			dataUrl,
+			blob,
 			download: (filename = 'screenshot.png') => {
 				const link = document.createElement('a');
 				link.download = filename;
-				link.href = pngDataUrl;
+				link.href = dataUrl;
+				document.body.appendChild(link);
 				link.click();
+				document.body.removeChild(link);
 			}
 		};
 	} catch (error) {


### PR DESCRIPTION
Resolves #389 

The native SVG-to-canvas approach in `screenshot.ts` was failing on Chromium and Gecko browsers. Users could not download the images they made in the selfie tool. 

Replaced the `<foreignObject>` with `html-to-image`. It handles the rendering edge cases properly and restores the download functionality. 

**What I did:**
* Added `html-to-image` via pnpm.
* Rewrote `captureNodeAsPNG` in `screenshot.ts` to use the new library.
* Ran `pnpm format` and `pnpm lint` to match code style.